### PR TITLE
fix: Vercel blank screen when Sanity env vars are missing

### DIFF
--- a/src/components/portfolio/PortfolioShell.tsx
+++ b/src/components/portfolio/PortfolioShell.tsx
@@ -41,6 +41,10 @@ function ShellInner() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (!sanityClient) {
+      setLoading(false);
+      return;
+    }
     Promise.all([
       sanityClient.fetch('*[_type == "project" && kind == "web"] | order(_createdAt asc)'),
       sanityClient.fetch('*[_type == "project" && kind == "game"] | order(_createdAt asc)'),

--- a/src/lib/sanityClient.ts
+++ b/src/lib/sanityClient.ts
@@ -1,8 +1,13 @@
-import { createClient } from '@sanity/client'
+import { createClient, type SanityClient } from '@sanity/client'
 
-export const sanityClient = createClient({
-  projectId: import.meta.env.PUBLIC_SANITY_PROJECT_ID ?? '',
-  dataset: import.meta.env.PUBLIC_SANITY_DATASET ?? 'production',
-  apiVersion: '2024-01-01',
-  useCdn: true,
-})
+const projectId = import.meta.env.PUBLIC_SANITY_PROJECT_ID?.trim() ?? ''
+
+/** `null` when `PUBLIC_SANITY_PROJECT_ID` is missing (e.g. Vercel env not set); `createClient` throws on empty id. */
+export const sanityClient: SanityClient | null = projectId
+  ? createClient({
+      projectId,
+      dataset: import.meta.env.PUBLIC_SANITY_DATASET ?? 'production',
+      apiVersion: '2024-01-01',
+      useCdn: true,
+    })
+  : null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The production bundle imported `@sanity/client` with an empty `projectId` when `PUBLIC_SANITY_PROJECT_ID` was not set on Vercel. `createClient` throws synchronously in that case, which crashed the React island before anything rendered (blank page; only shell/chrome visible).

## Change
- Only call `createClient` when a non-empty project ID is present; otherwise export `sanityClient` as `null`.
- In `PortfolioShell`, skip Sanity fetches and clear loading when the client is missing so the UI still mounts with empty CMS data.

## Follow-up
For live CMS content on Vercel, add `PUBLIC_SANITY_PROJECT_ID` (and optionally `PUBLIC_SANITY_DATASET`) in the Vercel project environment variables and redeploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-facfdc6e-7076-4896-b605-e013bedf4100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-facfdc6e-7076-4896-b605-e013bedf4100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

