### PR TITLE
Show UI immediately; disable custom cursor on mobile

### DIFF
--- a/src/components/PortfolioApp.tsx
+++ b/src/components/PortfolioApp.tsx
@@ -1,4 +1,19 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo, useSyncExternalStore } from 'react';
+
+const FINE_POINTER_MQ = '(hover: hover) and (pointer: fine)';
+
+function useFinePointer() {
+  return useSyncExternalStore(
+    (onChange) => {
+      if (typeof window === 'undefined') return () => {};
+      const mq = window.matchMedia(FINE_POINTER_MQ);
+      mq.addEventListener('change', onChange);
+      return () => mq.removeEventListener('change', onChange);
+    },
+    () => (typeof window !== 'undefined' ? window.matchMedia(FINE_POINTER_MQ).matches : false),
+    () => false
+  );
+}
 import { sanityClient } from '../lib/sanityClient';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -981,7 +996,7 @@ export default function PortfolioApp({ initialPage = 'home' }: { initialPage?: s
   const [posts, setPosts] = useState<Post[]>([]);
   const [nowItems, setNowItems] = useState<NowItem[]>([]);
   const [resume, setResume] = useState<Resume | null>(null);
-  const [loading, setLoading] = useState(true);
+  const finePointer = useFinePointer();
 
   useEffect(() => {
     Promise.all([
@@ -996,7 +1011,7 @@ export default function PortfolioApp({ initialPage = 'home' }: { initialPage?: s
       setPosts(ps ?? []);
       setNowItems(now ?? []);
       setResume(res ?? null);
-    }).finally(() => setLoading(false));
+    });
   }, []);
 
   useEffect(() => {
@@ -1034,8 +1049,9 @@ export default function PortfolioApp({ initialPage = 'home' }: { initialPage?: s
     setTimeout(() => setCurtain({ on: false, label: '' }), 820);
   }, [page]);
 
-  // Custom cursor
+  // Custom cursor (desktop / fine pointer only — avoids listeners and DOM on touch)
   useEffect(() => {
+    if (!finePointer) return;
     let rx = window.innerWidth / 2, ry = window.innerHeight / 2;
     let tx = rx, ty = ry;
     let raf: number;
@@ -1052,20 +1068,16 @@ export default function PortfolioApp({ initialPage = 'home' }: { initialPage?: s
     window.addEventListener('mousemove', mm);
     raf = requestAnimationFrame(tick);
     return () => { window.removeEventListener('mousemove', mm); cancelAnimationFrame(raf); };
-  }, []);
-
-  if (loading) {
-    return (
-      <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <span className="font-mono" style={{ color: 'var(--muted)', fontSize: 13, letterSpacing: '0.08em' }}>Loading...</span>
-      </div>
-    );
-  }
+  }, [finePointer]);
 
   return (
     <>
-      <div ref={dotRef} className="cursor-dot" />
-      <div ref={ringRef} className="cursor-ring" />
+      {finePointer && (
+        <>
+          <div ref={dotRef} className="cursor-dot" />
+          <div ref={ringRef} className="cursor-ring" />
+        </>
+      )}
 
       {curtain.on && (
         <div className="curtain sweep">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -302,7 +302,10 @@ button { font-family: inherit; cursor: pointer; }
 }
 .cursor-hot .cursor-dot { width: 28px; height: 28px; background: var(--lime); }
 .cursor-hot .cursor-ring { width: 56px; height: 56px; }
-@media (hover: none) { .cursor-dot, .cursor-ring { display: none; } }
+/* Touch / coarse pointer: no custom cursor overlay */
+@media (hover: none), (pointer: coarse) {
+  .cursor-dot, .cursor-ring { display: none !important; }
+}
 
 .about-grid { display: grid; grid-template-columns: 1.3fr 1fr; gap: 48px; align-items: start; }
 .portrait { aspect-ratio: 4/5; border: 2px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow-lg); overflow: hidden; position: relative; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removed the full-page "Loading..." gate so the portfolio shell renders immediately while Sanity data loads in the background.
- Custom cursor (DOM + `mousemove` + `requestAnimationFrame`) only runs when `(hover: hover) and (pointer: fine)` matches, so touch phones and tablets do not run the cursor logic.
- CSS hides `.cursor-dot` / `.cursor-ring` for `(hover: none)` or `(pointer: coarse)` as a fallback.

## Testing

- `npm install` and `npm run build` completed successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a473ad9-937e-4b87-a1cb-b413b92a1e24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a473ad9-937e-4b87-a1cb-b413b92a1e24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

