### PR TITLE
Fix mobile and tablet responsive layouts

### DIFF
--- a/src/components/PortfolioApp.tsx
+++ b/src/components/PortfolioApp.tsx
@@ -630,12 +630,12 @@ function ContactPage() {
             </button>
           </form>
           <aside>
-            <div className="card" style={{ padding: 24, marginBottom: 18 }}>
+            <div className="card contact-aside-card">
               <div className="eyebrow" style={{ marginBottom: 10 }}>Direct</div>
               <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 28, letterSpacing: '-0.02em' }}>hi@joncolon.co</div>
               <div className="mono" style={{ marginTop: 8, color: 'var(--muted)' }}>Copy · opens mail</div>
             </div>
-            <div className="card" style={{ padding: 24, marginBottom: 18, background: 'var(--lime)' }}>
+            <div className="card contact-aside-card" style={{ background: 'var(--lime)' }}>
               <div className="eyebrow" style={{ marginBottom: 10, color: '#1a1a1a' }}>Elsewhere</div>
               <div style={{ display: 'grid', gap: 10 }}>
                 <a className="nav-link" style={{ justifySelf: 'start', background: '#141414', color: '#F4EFE6' }} href="https://x.com/joncolon">X / Twitter → @joncolon</a>
@@ -668,7 +668,7 @@ function ResumePage({ resume }: { resume: Resume | null }) {
           </div>
           <button className="btn btn-lime">Download PDF <span>↓</span></button>
         </div>
-        <div className="card flat" style={{ padding: '4px 32px' }}>
+        <div className="card flat resume-card-inner">
           <h3 className="eyebrow" style={{ margin: '28px 0 6px' }}>Work</h3>
           {resume.work.map((r, i) => (
             <div key={i} className="resume-row">
@@ -694,7 +694,7 @@ function ResumePage({ resume }: { resume: Resume | null }) {
             </div>
           ))}
           <h3 className="eyebrow" style={{ margin: '32px 0 16px' }}>Skills</h3>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, paddingBottom: 32 }}>
+          <div className="resume-skills">
             {resume.skills.map(s => <span key={s} className="pill">{s}</span>)}
           </div>
         </div>
@@ -886,7 +886,7 @@ function HomeBlogTeaser({ openPost, go, posts }: { openPost: (p: Post) => void; 
             <div style={{ aspectRatio: '16/10', borderBottom: '2px solid var(--line)', overflow: 'hidden' }}>
               <ThumbPost post={p} />
             </div>
-            <div style={{ padding: '20px 22px' }}>
+            <div className="blog-teaser-body">
               <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 10 }}>
                 <span className={`pill ${p.tag === 'Devlog' ? 'plum' : p.tag === 'Design' ? 'red' : p.tag === 'Code' ? 'cobalt' : 'lime'}`}>{p.tag}</span>
                 <span className="mono" style={{ color: 'var(--muted)' }}>{p.date}</span>

--- a/src/components/PortfolioApp.tsx
+++ b/src/components/PortfolioApp.tsx
@@ -354,7 +354,10 @@ function Hero({ go }: { go: (id: string) => void }) {
 
   return (
     <section className="hero wrap" ref={parallaxRef}>
-      <div style={{ position: 'absolute', inset: '40px 28px 40px auto', width: 360, pointerEvents: 'none', transform: 'translate(calc(var(--px, 0) * -12px), calc(var(--py, 0) * -8px))', transition: 'transform 120ms linear', zIndex: 0 }}>
+      <div
+        className="hero-backdrop"
+        style={{ position: 'absolute', inset: '40px 28px 40px auto', width: 360, pointerEvents: 'none', transform: 'translate(calc(var(--px, 0) * -12px), calc(var(--py, 0) * -8px))', transition: 'transform 120ms linear', zIndex: 0 }}
+      >
         <HeroBackdrop />
       </div>
       <div className="hero-grid" style={{ position: 'relative', zIndex: 1 }}>
@@ -724,7 +727,7 @@ function ProjectModal({ project, onClose }: { project: Project; onClose: () => v
           <p style={{ fontSize: 18, color: 'var(--ink-soft)', margin: '0 0 24px' }}>{project.desc}</p>
           {project.body.map((p, i) => <p key={i} style={{ fontSize: 16, lineHeight: 1.65, color: 'var(--ink-soft)' }}>{p}</p>)}
           {project.shots && (
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12, margin: '28px 0' }}>
+            <div className="modal-shots-grid">
               {project.shots.map((s, i) => (
                 <div key={i} style={{ aspectRatio: '4/3', border: '2px solid var(--line)', borderRadius: 10, overflow: 'hidden' }}>
                   <div className={`th ${s}`} style={{ width: '100%', height: '100%' }} />
@@ -877,7 +880,7 @@ function HomeBlogTeaser({ openPost, go, posts }: { openPost: (p: Post) => void; 
         </div>
         <button className="nav-link" onClick={() => go('blog')}>All posts →</button>
       </div>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 24 }}>
+      <div className="blog-teaser-grid">
         {teaserPosts.map((p) => (
           <article key={p.id} className="card" style={{ cursor: 'pointer' }} onClick={() => openPost(p)}>
             <div style={{ aspectRatio: '16/10', borderBottom: '2px solid var(--line)', overflow: 'hidden' }}>
@@ -902,7 +905,7 @@ function HomeCTA({ go }: { go: (id: string) => void }) {
   return (
     <section className="section">
       <div className="wrap">
-        <div style={{ border: '2px solid var(--line)', borderRadius: 24, padding: '64px 40px', background: 'var(--ink)', color: 'var(--bg)', display: 'grid', gridTemplateColumns: '1.3fr 1fr', gap: 40, alignItems: 'center', boxShadow: 'var(--shadow-lg)' }}>
+        <div className="home-cta-panel">
           <div>
             <div style={{ fontFamily: 'var(--font-mono)', fontSize: 12, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--red)', marginBottom: 14 }}>→ Available May 2026</div>
             <div className="display" style={{ fontSize: 'clamp(40px, 6vw, 78px)', lineHeight: 0.95, margin: 0 }}>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,7 +15,7 @@ const {
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content={description} />
     <link rel="icon" type="image/png" href="/icon.png" />
     <title>{title}</title>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -391,30 +391,96 @@ button { font-family: inherit; cursor: pointer; }
 .th.plum-solid { background: var(--plum); }
 .th.lime-solid { background: var(--lime); }
 
+/* Tablet / narrow desktop: keep 2-column work + now grids; stack complex rows */
 @media (max-width: 980px) {
+  .section { padding: 72px 0; }
+  .wrap { padding: 0 20px; }
+  .nav-inner { padding: 14px 20px; }
+  .hero { padding: 48px 0 32px; }
   .hero-grid { grid-template-columns: 1fr; gap: 28px; }
   .hero-side { grid-template-columns: 1fr 1fr; display: grid; }
-  .work-grid { grid-template-columns: 1fr; }
+  .hero-backdrop { display: none; }
   .devlog-entry { grid-template-columns: 1fr; gap: 8px; }
   .devlog-thumb { width: 100%; height: 160px; justify-self: stretch; }
   .about-grid { grid-template-columns: 1fr; }
-  .now-grid { grid-template-columns: 1fr; }
-  .now-card.big { grid-column: span 1; }
+  .now-grid { grid-template-columns: repeat(2, 1fr); }
+  .now-card.big { grid-column: span 2; }
   .contact-grid { grid-template-columns: 1fr; }
-  .footer-grid { grid-template-columns: 1fr 1fr; }
+  .footer-grid { grid-template-columns: 1fr 1fr; gap: 28px; }
   .resume-row { grid-template-columns: 1fr; }
   .resume-tag { justify-self: start; }
+  .modal-body { padding: 24px 20px; }
   .nav-links { display: none; }
   .nav-links.open {
     display: flex; position: fixed; top: 64px; left: 0; right: 0;
     background: var(--bg); border-bottom: 2px solid var(--line);
-    flex-direction: column; padding: 16px 28px; gap: 8px; align-items: stretch;
+    flex-direction: column; padding: 16px 20px; gap: 8px; align-items: stretch;
   }
 }
+
+/* Phone: single column grids, tighter spacing */
+@media (max-width: 639px) {
+  .section { padding: 56px 0; }
+  .section-head { margin-bottom: 28px; }
+  .work-grid { grid-template-columns: 1fr; gap: 20px; }
+  .now-grid { grid-template-columns: 1fr; }
+  .now-card.big { grid-column: span 1; }
+  .footer-grid { grid-template-columns: 1fr; }
+  .hero-side { grid-template-columns: 1fr; }
+  .fact { grid-template-columns: 1fr; gap: 6px; }
+  .footer-bottom { flex-direction: column; align-items: flex-start; gap: 12px; }
+}
+
 .mobile-menu-btn { display: none; }
 @media (max-width: 980px) {
   .mobile-menu-btn {
     display: grid; place-items: center; width: 42px; height: 42px;
     border: 2px solid var(--line); border-radius: 999px; background: var(--bg); font-size: 18px;
   }
+}
+
+/* React islands: responsive grids (inline styles can't use media queries) */
+.blog-teaser-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+@media (max-width: 980px) {
+  .blog-teaser-grid { grid-template-columns: repeat(2, 1fr); gap: 20px; }
+}
+@media (max-width: 639px) {
+  .blog-teaser-grid { grid-template-columns: 1fr; gap: 20px; }
+}
+
+.home-cta-panel {
+  border: 2px solid var(--line);
+  border-radius: 24px;
+  padding: 64px 40px;
+  background: var(--ink);
+  color: var(--bg);
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 40px;
+  align-items: center;
+  box-shadow: var(--shadow-lg);
+}
+@media (max-width: 980px) {
+  .home-cta-panel {
+    grid-template-columns: 1fr;
+    padding: 40px 28px;
+    gap: 28px;
+  }
+}
+@media (max-width: 639px) {
+  .home-cta-panel { padding: 32px 22px; }
+}
+
+.modal-shots-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin: 28px 0;
+}
+@media (max-width: 639px) {
+  .modal-shots-grid { grid-template-columns: 1fr; }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -22,6 +22,8 @@
   --font-display: 'Bricolage Grotesque', system-ui, sans-serif;
   --font-body: 'Space Grotesk', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+  /* Horizontal inset for page chrome + notched devices */
+  --page-gutter: 28px;
 }
 
 [data-theme="dark"] {
@@ -78,7 +80,12 @@ button { font-family: inherit; cursor: pointer; }
   color: var(--muted);
 }
 
-.wrap { max-width: 1240px; margin: 0 auto; padding: 0 28px; }
+.wrap {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding-left: max(var(--page-gutter), env(safe-area-inset-left, 0px));
+  padding-right: max(var(--page-gutter), env(safe-area-inset-right, 0px));
+}
 .section { padding: 96px 0; position: relative; }
 .section-tight { padding: 56px 0; }
 
@@ -90,7 +97,12 @@ button { font-family: inherit; cursor: pointer; }
 }
 .nav-inner {
   display: flex; align-items: center; justify-content: space-between;
-  padding: 14px 28px; max-width: 1240px; margin: 0 auto;
+  padding-top: 14px;
+  padding-bottom: 14px;
+  padding-left: max(var(--page-gutter), env(safe-area-inset-left, 0px));
+  padding-right: max(var(--page-gutter), env(safe-area-inset-right, 0px));
+  max-width: 1240px;
+  margin: 0 auto;
 }
 .logo {
   display: inline-flex; align-items: center; gap: 10px;
@@ -248,7 +260,7 @@ button { font-family: inherit; cursor: pointer; }
 }
 .work-card:hover { transform: translate(-4px, -4px); box-shadow: 11px 11px 0 var(--line); }
 .work-thumb { aspect-ratio: 16/10; border-bottom: 2px solid var(--line); position: relative; overflow: hidden; }
-.work-meta { padding: 18px 20px 20px; display: flex; flex-direction: column; gap: 8px; }
+.work-meta { padding: 18px var(--page-gutter) 20px; display: flex; flex-direction: column; gap: 8px; }
 .work-title { font-family: var(--font-display); font-weight: 800; font-size: 28px; letter-spacing: -0.02em; line-height: 1; }
 .work-desc { color: var(--ink-soft); font-size: 15px; margin: 0; }
 .work-tags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 6px; }
@@ -265,7 +277,9 @@ button { font-family: inherit; cursor: pointer; }
 }
 .devlog-entry {
   display: grid; grid-template-columns: 140px 1fr 180px;
-  gap: 20px; padding: 22px 24px; border-bottom: 2px solid var(--line);
+  gap: 20px;
+  padding: 22px max(var(--page-gutter), 20px);
+  border-bottom: 2px solid var(--line);
   align-items: center; transition: background var(--t-fast); cursor: pointer;
 }
 .devlog-entry:last-child { border-bottom: none; }
@@ -352,19 +366,25 @@ button { font-family: inherit; cursor: pointer; }
 
 .modal-backdrop {
   position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 150;
-  display: grid; place-items: center; padding: 40px 20px;
+  display: grid; place-items: center;
+  padding-top: max(24px, env(safe-area-inset-top, 0px));
+  padding-bottom: max(24px, env(safe-area-inset-bottom, 0px));
+  padding-left: max(var(--page-gutter), env(safe-area-inset-left, 0px));
+  padding-right: max(var(--page-gutter), env(safe-area-inset-right, 0px));
   animation: fade 200ms ease both; overflow-y: auto;
 }
 @keyframes fade { from { opacity: 0; } to { opacity: 1; } }
 .modal {
   background: var(--bg); color: var(--ink); border: 2px solid var(--line);
   border-radius: var(--radius); box-shadow: var(--shadow-lg);
-  max-width: 860px; width: 100%; max-height: calc(100vh - 80px); overflow-y: auto;
+  max-width: 860px; width: 100%;
+  max-height: min(calc(100dvh - 48px), calc(100vh - 48px));
+  overflow-y: auto;
   animation: pop 300ms cubic-bezier(.2,.8,.2,1) both;
 }
 @keyframes pop { from { opacity: 0; transform: translateY(20px) scale(0.96); } to { opacity: 1; transform: translateY(0) scale(1); } }
 .modal-hero { aspect-ratio: 16/9; border-bottom: 2px solid var(--line); position: relative; overflow: hidden; }
-.modal-body { padding: 32px; }
+.modal-body { padding: 32px max(24px, var(--page-gutter)); }
 .modal-close {
   position: absolute; top: 20px; right: 20px; width: 40px; height: 40px;
   border-radius: 999px; border: 2px solid var(--line); background: var(--bg);
@@ -393,9 +413,8 @@ button { font-family: inherit; cursor: pointer; }
 
 /* Tablet / narrow desktop: keep 2-column work + now grids; stack complex rows */
 @media (max-width: 980px) {
+  :root { --page-gutter: 22px; }
   .section { padding: 72px 0; }
-  .wrap { padding: 0 20px; }
-  .nav-inner { padding: 14px 20px; }
   .hero { padding: 48px 0 32px; }
   .hero-grid { grid-template-columns: 1fr; gap: 28px; }
   .hero-side { grid-template-columns: 1fr 1fr; display: grid; }
@@ -409,17 +428,18 @@ button { font-family: inherit; cursor: pointer; }
   .footer-grid { grid-template-columns: 1fr 1fr; gap: 28px; }
   .resume-row { grid-template-columns: 1fr; }
   .resume-tag { justify-self: start; }
-  .modal-body { padding: 24px 20px; }
+  .modal-body { padding: 28px max(20px, var(--page-gutter)); }
   .nav-links { display: none; }
   .nav-links.open {
     display: flex; position: fixed; top: 64px; left: 0; right: 0;
     background: var(--bg); border-bottom: 2px solid var(--line);
-    flex-direction: column; padding: 16px 20px; gap: 8px; align-items: stretch;
+    flex-direction: column; padding: 16px max(16px, var(--page-gutter)); gap: 8px; align-items: stretch;
   }
 }
 
 /* Phone: single column grids, tighter spacing */
 @media (max-width: 639px) {
+  :root { --page-gutter: 18px; }
   .section { padding: 56px 0; }
   .section-head { margin-bottom: 28px; }
   .work-grid { grid-template-columns: 1fr; gap: 20px; }
@@ -449,13 +469,13 @@ button { font-family: inherit; cursor: pointer; }
   .blog-teaser-grid { grid-template-columns: repeat(2, 1fr); gap: 20px; }
 }
 @media (max-width: 639px) {
-  .blog-teaser-grid { grid-template-columns: 1fr; gap: 20px; }
+  .blog-teaser-grid { grid-template-columns: 1fr; gap: 16px; }
 }
 
 .home-cta-panel {
   border: 2px solid var(--line);
   border-radius: 24px;
-  padding: 64px 40px;
+  padding: 64px max(32px, var(--page-gutter));
   background: var(--ink);
   color: var(--bg);
   display: grid;
@@ -467,12 +487,12 @@ button { font-family: inherit; cursor: pointer; }
 @media (max-width: 980px) {
   .home-cta-panel {
     grid-template-columns: 1fr;
-    padding: 40px 28px;
+    padding: 40px max(24px, var(--page-gutter));
     gap: 28px;
   }
 }
 @media (max-width: 639px) {
-  .home-cta-panel { padding: 32px 22px; }
+  .home-cta-panel { padding: 28px max(20px, var(--page-gutter)); }
 }
 
 .modal-shots-grid {
@@ -483,4 +503,24 @@ button { font-family: inherit; cursor: pointer; }
 }
 @media (max-width: 639px) {
   .modal-shots-grid { grid-template-columns: 1fr; }
+}
+
+.blog-teaser-body {
+  padding: 20px max(18px, var(--page-gutter));
+}
+
+.contact-aside-card {
+  padding: 24px var(--page-gutter);
+  margin-bottom: 18px;
+}
+
+.resume-card-inner {
+  padding: 4px var(--page-gutter) max(28px, var(--page-gutter));
+}
+
+.resume-skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-bottom: max(24px, var(--page-gutter));
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -86,8 +86,9 @@ button { font-family: inherit; cursor: pointer; }
   padding-left: max(var(--page-gutter), env(safe-area-inset-left, 0px));
   padding-right: max(var(--page-gutter), env(safe-area-inset-right, 0px));
 }
-.section { padding: 96px 0; position: relative; }
-.section-tight { padding: 56px 0; }
+/* Use padding-block only — never padding shorthand here, or it overrides .wrap side padding when both classes share one element */
+.section { padding-block: 96px; position: relative; }
+.section-tight { padding-block: 56px; }
 
 .nav {
   position: sticky; top: 0; z-index: 50;
@@ -193,7 +194,7 @@ button { font-family: inherit; cursor: pointer; }
 
 .marquee {
   overflow: hidden; border-top: 2px solid var(--line); border-bottom: 2px solid var(--line);
-  background: var(--ink); color: var(--bg); padding: 14px 0;
+  background: var(--ink); color: var(--bg); padding-block: 14px;
 }
 .marquee-track {
   display: inline-flex; gap: 36px; white-space: nowrap;
@@ -204,15 +205,16 @@ button { font-family: inherit; cursor: pointer; }
 .marquee-track .dot { width: 14px; height: 14px; border-radius: 999px; background: var(--red); display: inline-block; }
 @keyframes marquee { to { transform: translateX(-50%); } }
 
-.hero { padding: 60px 0 40px; position: relative; }
+.hero { padding-block: 60px 40px; position: relative; }
 .hero-grid { display: grid; grid-template-columns: 1fr 380px; gap: 48px; align-items: end; }
+.hero-grid > * { min-width: 0; }
 .hero-kicker { display: inline-flex; align-items: center; gap: 10px; margin-bottom: 18px; }
 .hero-title { font-size: clamp(56px, 11vw, 168px); margin: 0 0 12px; }
 .hero-title .word { display: inline-block; }
 .hero-title .accent { color: var(--red); font-style: italic; }
 .hero-title .outline { -webkit-text-stroke: 3px var(--ink); color: transparent; }
 [data-theme="dark"] .hero-title .outline { -webkit-text-stroke-color: var(--ink); }
-.hero-sub { font-size: 22px; line-height: 1.35; max-width: 640px; margin: 20px 0 28px; color: var(--ink-soft); }
+.hero-sub { font-size: 22px; line-height: 1.35; max-width: 640px; margin: 20px 0 28px; color: var(--ink-soft); overflow-wrap: anywhere; }
 .typing {
   display: inline-block; border-right: 3px solid var(--red); padding-right: 2px;
   white-space: nowrap; overflow: hidden; vertical-align: baseline;
@@ -289,7 +291,7 @@ button { font-family: inherit; cursor: pointer; }
 .devlog-excerpt { font-size: 14px; color: var(--ink-soft); margin-top: 4px; }
 .devlog-thumb { width: 180px; height: 100px; border: 2px solid var(--line); border-radius: 10px; overflow: hidden; justify-self: end; }
 
-.footer { border-top: 2px solid var(--line); padding: 40px 0 28px; margin-top: 60px; }
+.footer { border-top: 2px solid var(--line); padding-block: 40px 28px; margin-top: 60px; }
 .footer-grid { display: grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap: 32px; margin-bottom: 40px; }
 .footer h4 { font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.14em; text-transform: uppercase; margin: 0 0 14px; color: var(--muted); }
 .footer ul { list-style: none; padding: 0; margin: 0; }
@@ -414,8 +416,8 @@ button { font-family: inherit; cursor: pointer; }
 /* Tablet / narrow desktop: keep 2-column work + now grids; stack complex rows */
 @media (max-width: 980px) {
   :root { --page-gutter: 22px; }
-  .section { padding: 72px 0; }
-  .hero { padding: 48px 0 32px; }
+  .section { padding-block: 72px; }
+  .hero { padding-block: 48px 32px; }
   .hero-grid { grid-template-columns: 1fr; gap: 28px; }
   .hero-side { grid-template-columns: 1fr 1fr; display: grid; }
   .hero-backdrop { display: none; }
@@ -440,7 +442,7 @@ button { font-family: inherit; cursor: pointer; }
 /* Phone: single column grids, tighter spacing */
 @media (max-width: 639px) {
   :root { --page-gutter: 18px; }
-  .section { padding: 56px 0; }
+  .section { padding-block: 56px; }
   .section-head { margin-bottom: 28px; }
   .work-grid { grid-template-columns: 1fr; gap: 20px; }
   .now-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The previous single breakpoint at 980px forced **one-column** work grids and **one-column** “now” cards on tablets, which looked wrong next to desktop. Inline React grids (devlog teaser, home CTA, project modal shots) also stayed desktop-only because they used fixed `gridTemplateColumns` in styles.

## Changes

- **Tablet (≤980px):** Keep **2-column** work grids and **2-column** now grid (wide card still spans 2); hide the hero backdrop SVG so it does not overlap content; slightly reduce section padding and horizontal gutters.
- **Phone (≤639px):** Stack work, now, hero stat cards, footer, and fact rows to **one column**; stack footer meta; tighten spacing.
- **React sections:** Replace inline grids with CSS classes `.blog-teaser-grid`, `.home-cta-panel`, `.modal-shots-grid` so they respond at breakpoints.

## Padding

- Introduced **`--page-gutter`** (28px desktop → 22px tablet → 18px phone) and applied **`max(var(--page-gutter), env(safe-area-inset-*))`** to `.wrap`, `.nav-inner`, work cards, devlog rows, modals, and the home CTA panel.
- Replaced fixed inline padding on contact aside cards, resume block, and blog teaser card bodies with classes.
- **`viewport-fit=cover`** in the layout meta tag; modal backdrop uses safe-area padding; modal max-height uses **`min(100dvh, 100vh)`**.

## Side spacing bugfix (critical)

Several elements use **both** `.wrap` and `.section` / `.hero` on the **same** node (e.g. `section class="section wrap"`). The old rules used **`padding: 96px 0`** / **`padding: 60px 0 40px`**, which is shorthand and **resets horizontal padding to 0**, wiping out `.wrap`’s side gutters. Replaced with **`padding-block`** only so horizontal padding from `.wrap` is preserved. Added **`min-width: 0`** on hero grid columns and **`overflow-wrap: anywhere`** on `.hero-sub` to avoid text clipping on narrow widths.

Build verified with `npm run build`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29d7723c-e6ab-4572-a4c8-91cbc93ada78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29d7723c-e6ab-4572-a4c8-91cbc93ada78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

