### PR TITLE
Prevent hero typing animation from shifting page layout

### DIFF
--- a/src/components/PortfolioApp.tsx
+++ b/src/components/PortfolioApp.tsx
@@ -312,6 +312,10 @@ function Hero({ go }: { go: (id: string) => void }) {
     'things that click',
     'pixel art at 2 a.m.',
   ], []);
+  const longestPhrase = useMemo(
+    () => phrases.reduce((a, b) => (a.length >= b.length ? a : b), phrases[0] ?? ''),
+    [phrases]
+  );
   const [idx, setIdx] = useState(0);
   const [sub, setSub] = useState('');
   const [phase, setPhase] = useState<'typing' | 'deleting'>('typing');
@@ -375,7 +379,12 @@ function Hero({ go }: { go: (id: string) => void }) {
           </h1>
           <p className="hero-sub">
             Designer, developer and part-time game dev. Currently making{' '}
-            <span className="typing">{sub}</span>
+            <span className="hero-typing-slot">
+              <span className="typing typing-measure" aria-hidden="true">
+                {longestPhrase}
+              </span>
+              <span className="typing typing-live">{sub}</span>
+            </span>
           </p>
           <div className="hero-ctas">
             <button className="btn" onClick={() => go('web')}>See the work <span>→</span></button>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -215,11 +215,27 @@ button { font-family: inherit; cursor: pointer; }
 .hero-title .outline { -webkit-text-stroke: 3px var(--ink); color: transparent; }
 [data-theme="dark"] .hero-title .outline { -webkit-text-stroke-color: var(--ink); }
 .hero-sub { font-size: 22px; line-height: 1.35; max-width: 640px; margin: 20px 0 28px; color: var(--ink-soft); overflow-wrap: anywhere; }
+.hero-typing-slot {
+  position: relative;
+  display: inline-block;
+  vertical-align: baseline;
+}
 .typing {
   display: inline-block; border-right: 3px solid var(--red); padding-right: 2px;
   white-space: nowrap; overflow: hidden; vertical-align: baseline;
   font-family: var(--font-mono); font-size: 20px;
   animation: caret 0.8s step-end infinite;
+}
+.typing-measure {
+  visibility: hidden;
+  animation: none;
+  border-right-color: transparent;
+  pointer-events: none;
+}
+.typing-live {
+  position: absolute;
+  left: 0;
+  top: 0;
 }
 @keyframes caret { 50% { border-color: transparent; } }
 .hero-ctas { display: inline-flex; gap: 14px; flex-wrap: wrap; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The hero subtitle cycles through short phrases with a typewriter effect. As each phrase grew, the inline text width changed and the paragraph reflowed, which nudged the rest of the page.

## Changes

- Reserve horizontal space for the longest phrase in the rotation using an invisible measure span.
- Render the animated text in an absolutely positioned overlay so the document flow width stays constant while typing.

## Testing

- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fa4fbe7-6bc1-49b9-adbe-d76e0760eff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fa4fbe7-6bc1-49b9-adbe-d76e0760eff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

