### PR TITLE
Fix blank /admin page (auth query throws + queries before login)

### DIFF
--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
-import { requireContentAdmin } from "./lib/admin";
+import { checkContentAdmin, requireContentAdmin } from "./lib/admin";
 
 const RESUME_SETTINGS_KEY = "resume";
 
@@ -70,21 +70,27 @@ export const getResumePdf = query({
 export const getResumePdfAdmin = query({
   args: {},
   handler: async (ctx) => {
-    await requireContentAdmin(ctx);
+    const gate = await checkContentAdmin(ctx);
+    if (!gate.ok) {
+      return { ok: false as const, error: gate.message };
+    }
     const settings = await ctx.db
       .query("siteSettings")
       .withIndex("by_key", (q) => q.eq("key", RESUME_SETTINGS_KEY))
       .unique();
     if (!settings?.resumeFileId) {
-      return null;
+      return { ok: true as const, resume: null };
     }
     const url = await ctx.storage.getUrl(settings.resumeFileId);
     return {
-      url,
-      filename: settings.resumeFileName ?? "resume.pdf",
-      contentType: settings.resumeContentType ?? null,
-      size: settings.resumeSize ?? null,
-      uploadedAt: settings.resumeUploadedAt ?? null,
+      ok: true as const,
+      resume: {
+        url,
+        filename: settings.resumeFileName ?? "resume.pdf",
+        contentType: settings.resumeContentType ?? null,
+        size: settings.resumeSize ?? null,
+        uploadedAt: settings.resumeUploadedAt ?? null,
+      },
     };
   },
 });

--- a/convex/contacts.ts
+++ b/convex/contacts.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
-import { requireContentAdmin } from "./lib/admin";
+import { checkContentAdmin, requireContentAdmin } from "./lib/admin";
 
 const contactKindValue = v.union(
   v.literal("Project inquiry"),
@@ -38,7 +38,11 @@ export const submitContact = mutation({
 export const listContactsAdmin = query({
   args: {},
   handler: async (ctx) => {
-    await requireContentAdmin(ctx);
-    return await ctx.db.query("contacts").withIndex("by_submitted_at").order("desc").take(250);
+    const gate = await checkContentAdmin(ctx);
+    if (!gate.ok) {
+      return { ok: false as const, error: gate.message };
+    }
+    const contacts = await ctx.db.query("contacts").withIndex("by_submitted_at").order("desc").take(250);
+    return { ok: true as const, contacts };
   },
 });

--- a/convex/lib/admin.ts
+++ b/convex/lib/admin.ts
@@ -3,17 +3,35 @@ import type { DataModel } from "../_generated/dataModel";
 
 type AuthCtx = GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>;
 
+export type ContentAdminGate = { ok: true } | { ok: false; message: string };
+
+/**
+ * Same rules as {@link requireContentAdmin}, but returns a result so public
+ * queries can respond without throwing (Convex React `useQuery` throws on
+ * query errors and would blank the admin UI).
+ */
+export async function checkContentAdmin(ctx: AuthCtx): Promise<ContentAdminGate> {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) {
+    return { ok: false, message: "Not authenticated" };
+  }
+  const adminEmail = process.env.ADMIN_EMAIL;
+  if (adminEmail && identity.email !== adminEmail) {
+    return {
+      ok: false,
+      message: "Unauthorized: this account cannot edit portfolio content.",
+    };
+  }
+  return { ok: true };
+}
+
 /**
  * Requires a signed-in user. If Convex env `ADMIN_EMAIL` is set, only that
  * email may call content mutations (recommended for production).
  */
 export async function requireContentAdmin(ctx: AuthCtx): Promise<void> {
-  const identity = await ctx.auth.getUserIdentity();
-  if (!identity) {
-    throw new Error("Not authenticated");
-  }
-  const adminEmail = process.env.ADMIN_EMAIL;
-  if (adminEmail && identity.email !== adminEmail) {
-    throw new Error("Unauthorized: this account cannot edit portfolio content.");
+  const gate = await checkContentAdmin(ctx);
+  if (!gate.ok) {
+    throw new Error(gate.message);
   }
 }

--- a/convex/lib/admin.ts
+++ b/convex/lib/admin.ts
@@ -1,9 +1,34 @@
+import { getAuthUserId } from "@convex-dev/auth/server";
 import type { GenericMutationCtx, GenericQueryCtx } from "convex/server";
 import type { DataModel } from "../_generated/dataModel";
 
 type AuthCtx = GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>;
 
 export type ContentAdminGate = { ok: true } | { ok: false; message: string };
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/**
+ * Emails Convex Auth may associate with the session. JWT `email` is often
+ * absent; the `users` row from {@link getAuthUserId} holds the profile email.
+ */
+async function sessionAdminEmails(ctx: AuthCtx): Promise<Set<string>> {
+  const identity = await ctx.auth.getUserIdentity();
+  const emails = new Set<string>();
+  if (identity?.email) {
+    emails.add(normalizeEmail(identity.email));
+  }
+  const userId = await getAuthUserId(ctx);
+  if (userId) {
+    const user = await ctx.db.get(userId);
+    if (user?.email) {
+      emails.add(normalizeEmail(user.email));
+    }
+  }
+  return emails;
+}
 
 /**
  * Same rules as {@link requireContentAdmin}, but returns a result so public
@@ -15,11 +40,17 @@ export async function checkContentAdmin(ctx: AuthCtx): Promise<ContentAdminGate>
   if (!identity) {
     return { ok: false, message: "Not authenticated" };
   }
-  const adminEmail = process.env.ADMIN_EMAIL;
-  if (adminEmail && identity.email !== adminEmail) {
+  const rawAdmin = process.env.ADMIN_EMAIL?.trim();
+  if (!rawAdmin) {
+    return { ok: true };
+  }
+  const want = normalizeEmail(rawAdmin);
+  const have = await sessionAdminEmails(ctx);
+  if (![...have].some((e) => e === want)) {
     return {
       ok: false,
-      message: "Unauthorized: this account cannot edit portfolio content.",
+      message:
+        "Unauthorized: your session does not match ADMIN_EMAIL (checked against your Convex Auth user email; comparison is case-insensitive). Sign out and sign in with the admin address, or update ADMIN_EMAIL in the Convex dashboard.",
     };
   }
   return { ok: true };

--- a/src/components/portfolio/ContentAdmin.tsx
+++ b/src/components/portfolio/ContentAdmin.tsx
@@ -129,8 +129,8 @@ function AdminInner() {
 
   const posts = useQuery(api.posts.listPosts, {});
   const projects = useQuery(api.projects.listProjects, {});
-  const contacts = useQuery(api.contacts.listContactsAdmin, {});
-  const resumePdf = useQuery(api.assets.getResumePdfAdmin, {});
+  const contactsResult = useQuery(api.contacts.listContactsAdmin, {});
+  const resumePdfResult = useQuery(api.assets.getResumePdfAdmin, {});
   const upsertPost = useMutation(api.posts.upsertPost);
   const upsertProject = useMutation(api.projects.upsertProject);
   const deletePost = useMutation(api.posts.deletePost);
@@ -207,13 +207,47 @@ function AdminInner() {
     );
   }
 
-  if (posts === undefined || projects === undefined || contacts === undefined || resumePdf === undefined) {
+  if (
+    posts === undefined ||
+    projects === undefined ||
+    contactsResult === undefined ||
+    resumePdfResult === undefined
+  ) {
     return (
       <div className="wrap section-tight">
         <p className="eyebrow">Loading…</p>
       </div>
     );
   }
+
+  if (!contactsResult.ok || !resumePdfResult.ok) {
+    const detail = !contactsResult.ok ? contactsResult.error : resumePdfResult.error;
+    return (
+      <div className="wrap section">
+        <header style={{ marginBottom: 28 }}>
+          <p className="eyebrow">Private</p>
+          <h1 className="display" style={{ fontSize: "clamp(2rem, 4vw, 3rem)", margin: "8px 0 0" }}>
+            Content admin
+          </h1>
+        </header>
+        <div className="card flat" style={{ padding: 24, maxWidth: 560 }}>
+          <p className="mono" style={{ color: "var(--red)", marginBottom: 16 }}>
+            {detail}
+          </p>
+          <p style={{ color: "var(--muted)", marginBottom: 20 }}>
+            If your deployment sets <code className="mono">ADMIN_EMAIL</code>, sign in with that exact email address,
+            or update the env var to match your Convex Auth account.
+          </p>
+          <button type="button" className="btn" onClick={() => void signOut()}>
+            Sign out
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const contacts = contactsResult.contacts;
+  const resumePdf = resumePdfResult.resume;
 
   return (
     <div className="wrap section">

--- a/src/components/portfolio/ContentAdmin.tsx
+++ b/src/components/portfolio/ContentAdmin.tsx
@@ -1,5 +1,5 @@
 import { ConvexAuthProvider, useAuthActions } from "@convex-dev/auth/react";
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { Component, useEffect, useMemo, useState, type FormEvent, type ReactNode } from "react";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
@@ -22,6 +22,50 @@ function formatAuthError(err: unknown): string {
     return err.message;
   }
   return String(err);
+}
+
+type AdminErrorBoundaryProps = { signOut: () => void; children: ReactNode };
+type AdminErrorBoundaryState = { error: Error | null };
+
+class AdminErrorBoundary extends Component<AdminErrorBoundaryProps, AdminErrorBoundaryState> {
+  state: AdminErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): AdminErrorBoundaryState {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="wrap section">
+          <header style={{ marginBottom: 28 }}>
+            <p className="eyebrow">Private</p>
+            <h1 className="display" style={{ fontSize: "clamp(2rem, 4vw, 3rem)", margin: "8px 0 0" }}>
+              Content admin
+            </h1>
+          </header>
+          <div className="card flat" style={{ padding: 24, maxWidth: 640 }}>
+            <p className="mono" style={{ color: "var(--red)", marginBottom: 12 }}>
+              {this.state.error.message}
+            </p>
+            <p style={{ color: "var(--muted)", marginBottom: 20 }}>
+              This usually means the browser is talking to a different Convex deployment than the one your functions
+              were pushed to, or a query failed on the server. After deploying Convex, reload this page.
+            </p>
+            <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+              <button type="button" className="btn" onClick={() => this.setState({ error: null })}>
+                Try again
+              </button>
+              <button type="button" className="btn btn-ghost" onClick={() => this.props.signOut()}>
+                Sign out
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
 }
 
 function AdminSignIn() {
@@ -121,8 +165,8 @@ function AdminSignIn() {
   );
 }
 
-function AdminInner() {
-  const { isLoading, isAuthenticated } = useConvexAuth();
+/** Convex `useQuery` throws on server errors; keep hooks out of the unauthenticated tree so the login form never crashes. */
+function AdminAuthenticated() {
   const { signOut } = useAuthActions();
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -180,32 +224,6 @@ function AdminInner() {
       setError(err instanceof Error ? err.message : String(err));
     }
   };
-
-  if (isLoading) {
-    return (
-      <div className="wrap section-tight">
-        <p className="eyebrow">Checking session…</p>
-      </div>
-    );
-  }
-
-  if (!isAuthenticated) {
-    return (
-      <div className="wrap section">
-        <header style={{ marginBottom: 28 }}>
-          <p className="eyebrow">Private</p>
-          <h1 className="display" style={{ fontSize: "clamp(2rem, 4vw, 3rem)", margin: "8px 0 0" }}>
-            Content admin
-          </h1>
-          <p style={{ color: "var(--muted)", maxWidth: 560, marginTop: 12 }}>
-            Sign in with Convex Auth (email + password). If your deployment sets{" "}
-            <code className="mono">ADMIN_EMAIL</code>, only that address can save content.
-          </p>
-        </header>
-        <AdminSignIn />
-      </div>
-    );
-  }
 
   if (
     posts === undefined ||
@@ -787,6 +805,43 @@ function AdminInner() {
         </div>
       )}
     </div>
+  );
+}
+
+function AdminInner() {
+  const { isLoading, isAuthenticated } = useConvexAuth();
+  const { signOut } = useAuthActions();
+
+  if (isLoading) {
+    return (
+      <div className="wrap section-tight">
+        <p className="eyebrow">Checking session…</p>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="wrap section">
+        <header style={{ marginBottom: 28 }}>
+          <p className="eyebrow">Private</p>
+          <h1 className="display" style={{ fontSize: "clamp(2rem, 4vw, 3rem)", margin: "8px 0 0" }}>
+            Content admin
+          </h1>
+          <p style={{ color: "var(--muted)", maxWidth: 560, marginTop: 12 }}>
+            Sign in with Convex Auth (email + password). If your deployment sets{" "}
+            <code className="mono">ADMIN_EMAIL</code>, only that address can save content.
+          </p>
+        </header>
+        <AdminSignIn />
+      </div>
+    );
+  }
+
+  return (
+    <AdminErrorBoundary signOut={() => void signOut()}>
+      <AdminAuthenticated />
+    </AdminErrorBoundary>
   );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After signing in on `/admin`, the page could go blank or show only the
`ADMIN_EMAIL` guidance with no tabs. Causes addressed:

1. **Admin queries throwing on auth** — fixed via structured `{ ok, error }` responses.

2. **Queries running while the login form is shown** — fixed by splitting
   `AdminAuthenticated` and an error boundary.

3. **`ADMIN_EMAIL` never matching even when “correct”** — Convex Auth’s
   default JWT does not include an `email` claim, so `identity.email` was
   often `undefined` while `ADMIN_EMAIL` was set. The strict `!==` check then
   always failed. **Fix:** resolve the signed-in user with `getAuthUserId`
   and compare `ADMIN_EMAIL` to the `users` document’s `email` (and JWT
   `email` when present), **case-insensitive** after trim.

## Testing

- `npm run build` passes locally.

## Deploy note

Merge and run **`npx convex deploy`** (or push to your Convex-linked branch)
so production picks up `convex/lib/admin.ts` changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-401e0a25-c30b-4ef4-a0a4-31d5f6376909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-401e0a25-c30b-4ef4-a0a4-31d5f6376909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

