### PR TITLE
Fix admin tags comma input and show media URL as project image

### DIFF
--- a/src/components/portfolio/ContentAdmin.tsx
+++ b/src/components/portfolio/ContentAdmin.tsx
@@ -1,10 +1,11 @@
 import { ConvexAuthProvider, useAuthActions } from "@convex-dev/auth/react";
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
 import type { Post, Project } from "../../data/portfolioContent";
 import { convexClient, hasConvex } from "../../lib/convexClient";
+import { ProjectThumb } from "./Thumbnails";
 
 function linesToBody(s: string): string[] {
   return s
@@ -15,6 +16,17 @@ function linesToBody(s: string): string[] {
 
 function bodyToLines(body: string[]): string {
   return body.join("\n");
+}
+
+function tagsToDraft(tags: string[] | undefined): string {
+  return (tags ?? []).join(", ");
+}
+
+function draftToTags(s: string): string[] {
+  return s
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
 }
 
 function formatAuthError(err: unknown): string {
@@ -151,6 +163,7 @@ function AdminWorkspace() {
 
   const [postForm, setPostForm] = useState<Partial<Post>>({});
   const [projectForm, setProjectForm] = useState<Partial<Project>>({});
+  const [projectTagsDraft, setProjectTagsDraft] = useState("");
 
   useEffect(() => {
     if (!selectedPost) {
@@ -167,6 +180,16 @@ function AdminWorkspace() {
     }
     setProjectForm({ ...selectedProject });
   }, [selectedProject]);
+
+  useEffect(() => {
+    if (!selectedProject) return;
+    setProjectTagsDraft(tagsToDraft(selectedProject.tags));
+  }, [selectedProject]);
+
+  const syncProjectTagsFromDraft = useCallback((draft: string) => {
+    setProjectTagsDraft(draft);
+    setProjectForm((f) => ({ ...f, tags: draftToTags(draft) }));
+  }, []);
 
   const run = async (fn: () => Promise<unknown>, ok: string) => {
     setError(null);
@@ -407,7 +430,10 @@ function AdminWorkspace() {
                     type="button"
                     className="btn btn-ghost"
                     style={{ width: "100%", textAlign: "left", fontSize: 14 }}
-                    onClick={() => setSelectedProjectId(p.id)}
+                    onClick={() => {
+                      setSelectedProjectId(p.id);
+                      setProjectTagsDraft(tagsToDraft(p.tags));
+                    }}
                   >
                     {p.title}
                   </button>
@@ -420,6 +446,7 @@ function AdminWorkspace() {
               style={{ marginTop: 16, width: "100%" }}
               onClick={() => {
                 setSelectedProjectId(null);
+                setProjectTagsDraft("");
                 setProjectForm({
                   id: "new-project",
                   title: "",
@@ -492,16 +519,8 @@ function AdminWorkspace() {
                 <div className="form-field">
                   <label>tags (comma-separated)</label>
                   <input
-                    value={(projectForm.tags ?? []).join(", ")}
-                    onChange={(e) =>
-                      setProjectForm((f) => ({
-                        ...f,
-                        tags: e.target.value
-                          .split(",")
-                          .map((t) => t.trim())
-                          .filter(Boolean),
-                      }))
-                    }
+                    value={projectTagsDraft}
+                    onChange={(e) => syncProjectTagsFromDraft(e.target.value)}
                   />
                 </div>
                 <div className="form-field">
@@ -545,6 +564,18 @@ function AdminWorkspace() {
                     value={projectForm.media ?? ""}
                     onChange={(e) => setProjectForm((f) => ({ ...f, media: e.target.value || undefined }))}
                   />
+                  <div
+                    style={{
+                      marginTop: 12,
+                      aspectRatio: "16 / 9",
+                      border: "2px solid var(--line)",
+                      borderRadius: 10,
+                      overflow: "hidden",
+                      background: "var(--paper-2)",
+                    }}
+                  >
+                    <ProjectThumb id={projectForm.id ?? ""} media={projectForm.media} />
+                  </div>
                 </div>
                 <div className="form-field">
                   <label>body (one paragraph per line)</label>

--- a/src/components/portfolio/Modals.tsx
+++ b/src/components/portfolio/Modals.tsx
@@ -29,7 +29,7 @@ export function ProjectModal({ project, onClose }: { project: Project; onClose: 
           ✕
         </button>
         <div className="modal-hero">
-          <ProjectThumb id={project.id} />
+          <ProjectThumb id={project.id} media={project.media} />
         </div>
         <div className="modal-body">
           <div style={{ display: 'flex', gap: 8, marginBottom: 14, flexWrap: 'wrap' }}>

--- a/src/components/portfolio/Thumbnails.tsx
+++ b/src/components/portfolio/Thumbnails.tsx
@@ -163,7 +163,25 @@ const THUMB_MAP: Record<string, () => ReactElement> = {
   thicket: ThumbThicket,
 };
 
-export function ProjectThumb({ id }: { id: string }) {
+/** Absolute URL for <img src>; add https:// when there is no scheme (e.g. admin-pasted domains). */
+function mediaImageSrc(raw: string | undefined): string | null {
+  const t = raw?.trim();
+  if (!t) return null;
+  if (/^https?:\/\//i.test(t)) return t;
+  return `https://${t}`;
+}
+
+export function ProjectThumb({ id, media }: { id: string; media?: string }) {
+  const src = mediaImageSrc(media);
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt=""
+        style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+      />
+    );
+  }
   const Component = THUMB_MAP[id];
   if (!Component) return <div className="th cobalt-solid" style={{ width: '100%', height: '100%' }} />;
   return <Component />;

--- a/src/components/portfolio/Work.tsx
+++ b/src/components/portfolio/Work.tsx
@@ -28,7 +28,7 @@ export function WorkCard({ project, onClick, i }: { project: Project; onClick: (
         <span className={`pill ${project.accent}`}>{project.year}</span>
       </div>
       <div className="work-thumb">
-        <ProjectThumb id={project.id} />
+        <ProjectThumb id={project.id} media={project.media} />
       </div>
       <div className="work-meta">
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, justifyContent: 'space-between' }}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Tags field:** The tags input was controlled by `tags.join(", ")`, so typing a comma produced a trailing empty segment that was removed on every keystroke—commas could not appear while editing. The admin form now keeps a separate draft string and parses tags on change, so commas and spacing behave naturally.
- **Media URL:** `ProjectThumb` only rendered built-in SVG thumbnails by project `id`, so a Convex `media` URL had no effect. When `media` is set, thumbnails now render that URL as a cover image (scheme-less URLs get `https://`, consistent with link helpers). Work cards, the project modal, and the admin form show a live preview under the media URL field.

## Testing

- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb49897d-f722-4001-9ba1-ce5316ac525e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb49897d-f722-4001-9ba1-ce5316ac525e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

