### PR TITLE
Rich admin body editor with Convex image uploads

### DIFF
--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -12,6 +12,23 @@ export const generateResumeUploadUrl = mutation({
   },
 });
 
+/** Admin-only: upload images embedded in post/project body HTML. */
+export const generateBodyImageUploadUrl = mutation({
+  args: {},
+  handler: async (ctx) => {
+    await requireContentAdmin(ctx);
+    return await ctx.storage.generateUploadUrl();
+  },
+});
+
+/** Public URL for a stored image (used in saved body HTML). */
+export const getBodyImageUrl = query({
+  args: { storageId: v.id("_storage") },
+  handler: async (ctx, { storageId }) => {
+    return (await ctx.storage.getUrl(storageId)) ?? null;
+  },
+});
+
 export const setResumePdf = mutation({
   args: {
     storageId: v.id("_storage"),

--- a/convex/posts.ts
+++ b/convex/posts.ts
@@ -10,7 +10,7 @@ const postValue = v.object({
   read: v.string(),
   tag: v.string(),
   thumb: v.string(),
-  body: v.array(v.string()),
+  body: v.union(v.array(v.string()), v.string()),
 });
 
 export const listPosts = query({

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -15,9 +15,9 @@ const projectValue = v.object({
   live: v.optional(v.string()),
   repo: v.optional(v.string()),
   itch: v.optional(v.string()),
-  media: v.optional(v.string()),
-  body: v.array(v.string()),
-  shots: v.optional(v.array(v.string())),
+    media: v.optional(v.string()),
+    body: v.union(v.array(v.string()), v.string()),
+    shots: v.optional(v.array(v.string())),
 });
 
 export const listProjects = query({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -26,7 +26,7 @@ export default defineSchema({
     repo: v.optional(v.string()),
     itch: v.optional(v.string()),
     media: v.optional(v.string()),
-    body: v.array(v.string()),
+    body: v.union(v.array(v.string()), v.string()),
     shots: v.optional(v.array(v.string())),
   })
     .index("by_project_id", ["id"])
@@ -40,7 +40,7 @@ export default defineSchema({
     read: v.string(),
     tag: v.string(),
     thumb: v.string(),
-    body: v.array(v.string()),
+    body: v.union(v.array(v.string()), v.string()),
   }).index("by_post_id", ["id"]),
 
   siteSettings: defineTable({

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,14 +13,23 @@
         "@convex-dev/auth": "^0.0.91",
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/postcss": "^4.2.4",
+        "@tiptap/extension-image": "^3.22.4",
+        "@tiptap/extension-link": "^3.22.4",
+        "@tiptap/extension-placeholder": "^3.22.4",
+        "@tiptap/react": "^3.22.4",
+        "@tiptap/starter-kit": "^3.22.4",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "astro": "^6.1.8",
         "convex": "^1.35.1",
+        "dompurify": "^3.4.1",
         "jose": "^6.2.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "tailwindcss": "^4.2.4"
+      },
+      "devDependencies": {
+        "@types/dompurify": "^3.0.5"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -944,6 +953,34 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
@@ -2217,6 +2254,460 @@
         "tailwindcss": "4.2.4"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.4.tgz",
+      "integrity": "sha512-vGIGm/HpqLg8EAAQXQ+koV+/S828OEpzocfWcPOwo1u2QUVf9dQG47Yy6JJ8zFFaJwfv4dBcOXli+7BrJwsxDQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.4.tgz",
+      "integrity": "sha512-7/61kNPbGFhMgM//zMknD0pSb69rGdRIkpulXOWS1JBrFHkH6hjZDfrOETNzgKkO+NlmzVl9rXSTv0xauS3lzA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.4.tgz",
+      "integrity": "sha512-jIaPKfNOQu2lhpbLDvtwlQqM+mjF+Kk+auHpzYjBnsuwUli1Cl5ZOau7RH+rru/SQvZe1DtpQlANujDywugZAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.4.tgz",
+      "integrity": "sha512-v4pux5Ql3THAEjaLMY4ldtdy/Xy2qU7PJLBkq8ugLp8qicaKC+tpqxp6sGif4vLIjz7Ap5hurRbTNbXzszyyHA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.4.tgz",
+      "integrity": "sha512-TB+d3fGcTixYjO7coKqTr1mGTJuqr8hjDCPUFgzuvKyJnBhqWITmBzQ/8CLq4rr6mihgGURbD3N+xkQuPAKFiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.4.tgz",
+      "integrity": "sha512-cnbxmVhAcc7X3G81QUYEmKP0ve2hRmvAiFXBuuv9RUtQlBiRnzmhHoJOMgkX0CsMR7+8kMRpTfeDUYq2xp5s5w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.4.tgz",
+      "integrity": "sha512-MEurzNXfMET3rhjpoPJYUgMfxTdTqbzT9+ToFrqNGAHocdXVm6m1hhO2frVC7fEtHPnxXKsn0Z3NUbCRkRTLuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.4.tgz",
+      "integrity": "sha512-XQKla1+703FqQJC48tPDVgt9ucGiFbIEmQdOg5L5o07z9a6/NzuaZAc+1zJ7NxcUZzy+z6wBn1PrVMTiqiSXlw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.4.tgz",
+      "integrity": "sha512-N9/yMDC35jJp0V/naL0+6gi4gUDUIcPpWEzFdCDWUSYBA8mt41c1kI1ZU7UTKYIBzTClenhYHRc2XKZxxx0+LQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.4.tgz",
+      "integrity": "sha512-DFuyYxgaZPgxum5z1yvJPbfYCvDdO8geXsdyqt0qYYdiat3aGE4ncJhiLRIFDhSHBhaZg5eCgu/YPYAN6jZnrA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.4.tgz",
+      "integrity": "sha512-UYBEUj3SFpKINIE7AdzcyeS3xICK+ee+YLBbuqNXyHStYChjJOohzJehqiqhjR16A88KQQ+ZjgyDcItKGygSog==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.4.tgz",
+      "integrity": "sha512-xq+a4dE7T6VwApCkh/yU3p30gn3F8g8Arb9CyEZm58/WIJUIGvHSTjDdHmvU16+kiWSBg+wOOsaFHhYjJjxcKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.4.tgz",
+      "integrity": "sha512-TUaj5f0Ir5qy9HKKt2ocnwfXKpZDYeHgbbP9gshKFzdq5PLe1RbIgkjfy6bnoI865cYjmPYWRjcT7XsKyIcb9Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.4.tgz",
+      "integrity": "sha512-cCI1HekGQwhY/MbgaKQ0R/7HcH5ZM1oFAyI/J72QGLC0XnF403S/OXoHMuBWr1mCu8hNiQWCzeNRJUty0iytNw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-image": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.22.4.tgz",
+      "integrity": "sha512-ZDc+fLaratTQ4IgnKcJJwfUgUgpcHjbZSBi6UQAILJwkflMy1Zxj8mpbma5P934nLSI+uDnR5ret6ZZLNITKhA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.4.tgz",
+      "integrity": "sha512-fVSDx5AYXgDI3v2zZIqb7V8EewthwM2NJ/ZCX+XaxRsqNEpnjVhgHs7UlvDqK1wj2OJ6zmUNjPtVlAFRxwT+HQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.4.tgz",
+      "integrity": "sha512-uoP3yus02uwGPVzW2QaEPJWVIrUb/r5nKm6c8DiJv9fNSX1+gykZZMg42c6GwRFLZ/vyfWjVCbAE03VMUqafgA==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.4.tgz",
+      "integrity": "sha512-Xe8UFvvHmyp/c/TJsFwlwU9CWACYbBirNsluJ3U1+H8BTu1wqdrT/AXR5uIXeyCl5kiWKgX5q71eHWbYFOrqrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.4.tgz",
+      "integrity": "sha512-H659KXTvggSypIDWSOJBZ37jh9pKjQriDDvYPYvOZCdfij0D0hsDXN/wXoypArneUkoBdgruHfTtMkFOaQlgkw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.4.tgz",
+      "integrity": "sha512-t/zhker4oIS78AIGYDdFFfZC6zSBlszfD7z/zqFLGCg5PHNNgkZK5hKj6Vyix6D2SapRn/ajnx+8mhbKIUH5eA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.4.tgz",
+      "integrity": "sha512-w77hPVf7pcHt97vfrybg/l0t5CimCd4y75OJKuHuo3CfgM5xbUP/gaPNMDyLLe7MYole/UHi/XvG3XjgzqTzAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.4.tgz",
+      "integrity": "sha512-de6dFkIhigiENESY6rNJ3yTVS/337ybfP30dNPudTwGe9oAu9ZCS+04j6QCvXSjhlI3ULiv7wiSHqrP26Gd+Hw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.22.4.tgz",
+      "integrity": "sha512-Z3wtWL+KufwkC7CkJge5enAxx4q8C3oOYixme02snY9zfjX3V/1pjAmEfP4wxScgM5GIuTEJ83B9Yz3wRzPA6Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.4.tgz",
+      "integrity": "sha512-aRHWQj42HiailXSC9LkKYM3jWMcSeGwOjbqM4PiuxQZmHVDRFmeHkfJItOdn2cSHaO0vuEVK+TvrWUWsBFi3pg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.4.tgz",
+      "integrity": "sha512-mM69uUW5cSxIhyEpWXi/YcfyupcJMDLCPEfYi62awH0iOP/LRoCv/nHjJq4Hyj/KxRJbe8HKwIUnqaCUf7m5Pg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.4.tgz",
+      "integrity": "sha512-08kGdbhIrA6h10GWXqOkqIveaBj5tmxclK208/nUIAlonI9hPd739vu7fmVtpnmqCnSSNpoRtU4u6Gj5at0ZpA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.4.tgz",
+      "integrity": "sha512-fOe8VptJvLPs32bNdUYo8SRyljwqKNQVXWW056VoXIc5en/59OdJlJQVeHI0jRRciH3MtrqODi/gfJR0VHNZ8A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.4.tgz",
+      "integrity": "sha512-hj8Qka6WcHRllHUdeSjDnq2XaisUo4KsoGJc1WcFpoa1Yd+OeD861zUMnV7DFVGdZRy45Obht0CUYJpXQ4yA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.22.4.tgz",
+      "integrity": "sha512-XIQZPwLakR1t8+Q1UeCpr+kUHDWxpJzGy9r2xUi3mpPd6Wh8dtNltScBkUlCcr0sqc6J1GF6Is02JJVQGmCZMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.22.4",
+        "@tiptap/extension-floating-menu": "^3.22.4"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.4.tgz",
+      "integrity": "sha512-qWjw+vfdin1rzMRpRU4cC5tLTwMJtUpXeQukv+6mOqqvhptuwuZBjUHImVEJaSPoHXS7+1ut+nTnrLyWyEuE5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.22.4",
+        "@tiptap/extension-blockquote": "^3.22.4",
+        "@tiptap/extension-bold": "^3.22.4",
+        "@tiptap/extension-bullet-list": "^3.22.4",
+        "@tiptap/extension-code": "^3.22.4",
+        "@tiptap/extension-code-block": "^3.22.4",
+        "@tiptap/extension-document": "^3.22.4",
+        "@tiptap/extension-dropcursor": "^3.22.4",
+        "@tiptap/extension-gapcursor": "^3.22.4",
+        "@tiptap/extension-hard-break": "^3.22.4",
+        "@tiptap/extension-heading": "^3.22.4",
+        "@tiptap/extension-horizontal-rule": "^3.22.4",
+        "@tiptap/extension-italic": "^3.22.4",
+        "@tiptap/extension-link": "^3.22.4",
+        "@tiptap/extension-list": "^3.22.4",
+        "@tiptap/extension-list-item": "^3.22.4",
+        "@tiptap/extension-list-keymap": "^3.22.4",
+        "@tiptap/extension-ordered-list": "^3.22.4",
+        "@tiptap/extension-paragraph": "^3.22.4",
+        "@tiptap/extension-strike": "^3.22.4",
+        "@tiptap/extension-text": "^3.22.4",
+        "@tiptap/extension-underline": "^3.22.4",
+        "@tiptap/extensions": "^3.22.4",
+        "@tiptap/pm": "^3.22.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2271,6 +2762,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -2330,10 +2831,23 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
@@ -3454,6 +3968,15 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domutils": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
@@ -3593,6 +4116,15 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-string-truncated-width": {
       "version": "1.2.1",
@@ -4329,6 +4861,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -5340,6 +5878,12 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
@@ -5537,6 +6081,135 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
       }
     },
     "node_modules/radix3": {
@@ -5858,6 +6531,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.6.0",
@@ -6454,6 +7133,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -6588,6 +7276,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,22 @@
     "@convex-dev/auth": "^0.0.91",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/postcss": "^4.2.4",
+    "@tiptap/extension-image": "^3.22.4",
+    "@tiptap/extension-link": "^3.22.4",
+    "@tiptap/extension-placeholder": "^3.22.4",
+    "@tiptap/react": "^3.22.4",
+    "@tiptap/starter-kit": "^3.22.4",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "astro": "^6.1.8",
     "convex": "^1.35.1",
+    "dompurify": "^3.4.1",
     "jose": "^6.2.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "tailwindcss": "^4.2.4"
+  },
+  "devDependencies": {
+    "@types/dompurify": "^3.0.5"
   }
 }

--- a/src/components/portfolio/AdminRichBodyEditor.tsx
+++ b/src/components/portfolio/AdminRichBodyEditor.tsx
@@ -1,0 +1,237 @@
+import { Link } from "@tiptap/extension-link";
+import { Image } from "@tiptap/extension-image";
+import { Placeholder } from "@tiptap/extension-placeholder";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { useConvex, useMutation } from "convex/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import { bodyToHtmlForEditor, editorHtmlToStorageBody } from "../../lib/portfolioBody";
+
+type BodyValue = string[] | string | undefined;
+
+export function AdminRichBodyEditor({
+  idPrefix,
+  body,
+  onChange,
+  label = "Body",
+  hint,
+}: {
+  idPrefix: string;
+  body: BodyValue;
+  onChange: (next: string[] | string) => void;
+  label?: string;
+  hint?: string;
+}) {
+  const convex = useConvex();
+  const generateBodyImageUploadUrl = useMutation(api.assets.generateBodyImageUploadUrl);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const initialHtml = bodyToHtmlForEditor(body);
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        heading: { levels: [2, 3] },
+      }),
+      Placeholder.configure({
+        placeholder: "Write the full article or project story here…",
+      }),
+      Link.configure({
+        openOnClick: false,
+        autolink: true,
+        defaultProtocol: "https",
+      }),
+      Image.configure({ inline: false, allowBase64: false }),
+    ],
+    content: initialHtml,
+    editorProps: {
+      attributes: {
+        class: "admin-rich-editor-content",
+        id: `${idPrefix}-rich-body`,
+        spellCheck: "true",
+      },
+    },
+    onUpdate: ({ editor: ed }) => {
+      onChange(editorHtmlToStorageBody(ed.getHTML()));
+    },
+  });
+
+  useEffect(() => {
+    if (!editor) return;
+    const next = bodyToHtmlForEditor(body);
+    const cur = editor.getHTML();
+    if (next === cur) return;
+    editor.commands.setContent(next, { emitUpdate: false });
+  }, [body, editor]);
+
+  const pickImage = useCallback(() => {
+    setUploadError(null);
+    fileInputRef.current?.click();
+  }, []);
+
+  const onImageFile = useCallback(
+    async (file: File | undefined) => {
+      if (!file || !editor) return;
+      if (!file.type.startsWith("image/")) {
+        setUploadError("Choose an image file (PNG, JPEG, GIF, WebP, …).");
+        return;
+      }
+      setUploading(true);
+      setUploadError(null);
+      try {
+        const uploadUrl = await generateBodyImageUploadUrl({});
+        const res = await fetch(uploadUrl, {
+          method: "POST",
+          headers: { "Content-Type": file.type },
+          body: file,
+        });
+        if (!res.ok) {
+          throw new Error("Upload failed.");
+        }
+        const payload = (await res.json()) as { storageId?: string };
+        if (!payload.storageId) {
+          throw new Error("No storage id returned.");
+        }
+        const imageUrl = await convex.query(api.assets.getBodyImageUrl, {
+          storageId: payload.storageId as Id<"_storage">,
+        });
+        if (!imageUrl) {
+          throw new Error("Could not resolve image URL.");
+        }
+        editor.chain().focus().setImage({ src: imageUrl, alt: file.name.replace(/"/g, "") }).run();
+        onChange(editorHtmlToStorageBody(editor.getHTML()));
+      } catch (e) {
+        setUploadError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setUploading(false);
+      }
+    },
+    [convex, editor, generateBodyImageUploadUrl, onChange],
+  );
+
+  const setLink = useCallback(() => {
+    if (!editor) return;
+    const prev = editor.getAttributes("link").href as string | undefined;
+    const next = window.prompt("Link URL", prev ?? "https://");
+    if (next === null) return;
+    const trimmed = next.trim();
+    if (trimmed === "") {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+      return;
+    }
+    const href = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+    editor.chain().focus().extendMarkRange("link").setLink({ href }).run();
+  }, [editor]);
+
+  if (!editor) {
+    return (
+      <div className="form-field">
+        <label>{label}</label>
+        <p className="admin-body-editor-hint">Loading editor…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="form-field">
+      <label htmlFor={`${idPrefix}-rich-body`}>{label}</label>
+      {hint ? <p className="admin-body-editor-hint">{hint}</p> : null}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        hidden
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          e.target.value = "";
+          void onImageFile(f);
+        }}
+      />
+      <div className="admin-rich-editor-wrap">
+        <div className="admin-rich-toolbar" role="toolbar" aria-label="Formatting">
+          <button
+            type="button"
+            className={`admin-rich-tool ${editor.isActive("bold") ? "is-active" : ""}`}
+            onClick={() => editor.chain().focus().toggleBold().run()}
+            aria-pressed={editor.isActive("bold")}
+          >
+            Bold
+          </button>
+          <button
+            type="button"
+            className={`admin-rich-tool ${editor.isActive("italic") ? "is-active" : ""}`}
+            onClick={() => editor.chain().focus().toggleItalic().run()}
+            aria-pressed={editor.isActive("italic")}
+          >
+            Italic
+          </button>
+          <button
+            type="button"
+            className={`admin-rich-tool ${editor.isActive("strike") ? "is-active" : ""}`}
+            onClick={() => editor.chain().focus().toggleStrike().run()}
+            aria-pressed={editor.isActive("strike")}
+          >
+            Strike
+          </button>
+          <span className="admin-rich-toolbar-sep" aria-hidden="true" />
+          <button
+            type="button"
+            className={`admin-rich-tool ${editor.isActive("heading", { level: 2 }) ? "is-active" : ""}`}
+            onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+          >
+            H2
+          </button>
+          <button
+            type="button"
+            className={`admin-rich-tool ${editor.isActive("heading", { level: 3 }) ? "is-active" : ""}`}
+            onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+          >
+            H3
+          </button>
+          <button
+            type="button"
+            className={`admin-rich-tool ${editor.isActive("blockquote") ? "is-active" : ""}`}
+            onClick={() => editor.chain().focus().toggleBlockquote().run()}
+          >
+            Quote
+          </button>
+          <span className="admin-rich-toolbar-sep" aria-hidden="true" />
+          <button
+            type="button"
+            className={`admin-rich-tool ${editor.isActive("bulletList") ? "is-active" : ""}`}
+            onClick={() => editor.chain().focus().toggleBulletList().run()}
+          >
+            List
+          </button>
+          <button
+            type="button"
+            className={`admin-rich-tool ${editor.isActive("orderedList") ? "is-active" : ""}`}
+            onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          >
+            1. List
+          </button>
+          <span className="admin-rich-toolbar-sep" aria-hidden="true" />
+          <button type="button" className="admin-rich-tool" onClick={() => setLink()}>
+            Link
+          </button>
+          <button type="button" className="admin-rich-tool" onClick={pickImage} disabled={uploading}>
+            {uploading ? "Uploading…" : "Image"}
+          </button>
+        </div>
+        {uploadError ? (
+          <p className="mono" style={{ color: "var(--red)", margin: "0 0 8px", fontSize: 13 }}>
+            {uploadError}
+          </p>
+        ) : null}
+        <EditorContent editor={editor} />
+      </div>
+      <p className="admin-body-meta">
+        Plain paragraphs save compactly; headings, lists, links, and images save as HTML.
+      </p>
+    </div>
+  );
+}

--- a/src/components/portfolio/AdminRichBodyEditor.tsx
+++ b/src/components/portfolio/AdminRichBodyEditor.tsx
@@ -229,9 +229,7 @@ export function AdminRichBodyEditor({
         ) : null}
         <EditorContent editor={editor} />
       </div>
-      <p className="admin-body-meta">
-        Plain paragraphs save compactly; headings, lists, links, and images save as HTML.
-      </p>
+      <p className="admin-body-meta">Saved as sanitized HTML so bold, links, and images show correctly on the site.</p>
     </div>
   );
 }

--- a/src/components/portfolio/ContentAdmin.tsx
+++ b/src/components/portfolio/ContentAdmin.tsx
@@ -5,18 +5,8 @@ import { api } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
 import type { Post, Project } from "../../data/portfolioContent";
 import { convexClient, hasConvex } from "../../lib/convexClient";
+import { AdminRichBodyEditor } from "./AdminRichBodyEditor";
 import { ProjectThumb } from "./Thumbnails";
-
-function linesToBody(s: string): string[] {
-  return s
-    .split("\n")
-    .map((l) => l.trim())
-    .filter(Boolean);
-}
-
-function bodyToLines(body: string[]): string {
-  return body.join("\n");
-}
 
 function tagsToDraft(tags: string[] | undefined): string {
   return (tags ?? []).join(", ");
@@ -79,7 +69,7 @@ function AdminSignIn() {
 
   return (
     <div
-      className="card flat"
+      className="card flat admin-form-card"
       style={{ padding: 24, maxWidth: 440, position: "relative", zIndex: 20, pointerEvents: "auto" }}
     >
       <p className="eyebrow" style={{ marginBottom: 8 }}>
@@ -205,29 +195,27 @@ function AdminWorkspace() {
 
   if (posts === undefined || projects === undefined || contacts === undefined || resumePdf === undefined) {
     return (
-      <div className="wrap section-tight">
+      <div className="wrap admin-section">
         <p className="eyebrow">Loading…</p>
       </div>
     );
   }
 
   return (
-    <div className="wrap section">
-      <header style={{ marginBottom: 32 }}>
-        <p className="eyebrow">Private</p>
-        <div style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-start", justifyContent: "space-between", gap: 16 }}>
-          <div>
-            <h1 className="display" style={{ fontSize: "clamp(2rem, 4vw, 3rem)", margin: "8px 0 0" }}>
-              Content admin
-            </h1>
-            <p style={{ color: "var(--muted)", maxWidth: 560, marginTop: 12 }}>
-              Signed in with Convex Auth. Mutations run with your session token.
-            </p>
-          </div>
-          <button type="button" className="btn btn-ghost" onClick={() => void signOut()}>
-            Sign out
-          </button>
+    <div className="wrap admin-section">
+      <header className="admin-header-row">
+        <div>
+          <p className="eyebrow">Private</p>
+          <h1 className="display" style={{ fontSize: "clamp(2rem, 4vw, 3rem)", margin: "8px 0 0" }}>
+            Content admin
+          </h1>
+          <p style={{ color: "var(--muted)", maxWidth: 560, marginTop: 12 }}>
+            Signed in with Convex Auth. Mutations run with your session token.
+          </p>
         </div>
+        <button type="button" className="btn btn-ghost" onClick={() => void signOut()}>
+          Sign out
+        </button>
       </header>
 
       {message && (
@@ -241,7 +229,7 @@ function AdminWorkspace() {
         </p>
       )}
 
-      <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
+      <div className="admin-tab-bar" role="tablist" aria-label="Admin sections">
         <button type="button" className={tab === "posts" ? "btn" : "btn btn-ghost"} onClick={() => setTab("posts")}>
           Posts ({sortedPosts.length})
         </button>
@@ -261,8 +249,8 @@ function AdminWorkspace() {
       </div>
 
       {tab === "posts" && (
-        <div style={{ display: "grid", gridTemplateColumns: "minmax(200px, 240px) 1fr", gap: 24 }}>
-          <nav style={{ borderRight: "2px solid var(--line)", paddingRight: 16 }}>
+        <div className="admin-split">
+          <nav className="admin-split-nav" aria-label="Post list">
             <p className="eyebrow" style={{ marginBottom: 12 }}>
               Posts
             </p>
@@ -305,7 +293,7 @@ function AdminWorkspace() {
             {!postForm.id && !selectedPostId ? (
               <p style={{ color: "var(--muted)" }}>Select a post or create a new one.</p>
             ) : (
-              <div className="card flat" style={{ padding: 20 }}>
+              <div className="card flat admin-form-card">
                 <div className="form-field">
                   <label>id (slug)</label>
                   <input
@@ -355,13 +343,12 @@ function AdminWorkspace() {
                     onChange={(e) => setPostForm((f) => ({ ...f, thumb: e.target.value }))}
                   />
                 </div>
-                <div className="form-field">
-                  <label>body (one paragraph per line)</label>
-                  <textarea
-                    value={bodyToLines(postForm.body ?? [])}
-                    onChange={(e) => setPostForm((f) => ({ ...f, body: linesToBody(e.target.value) }))}
-                  />
-                </div>
+                <AdminRichBodyEditor
+                  idPrefix="post"
+                  body={postForm.body}
+                  onChange={(next) => setPostForm((f) => ({ ...f, body: next }))}
+                  hint="Use the toolbar for bold, lists, links, and images. Images upload to Convex storage and embed in the article."
+                />
                 <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
                   <button
                     type="button"
@@ -418,8 +405,8 @@ function AdminWorkspace() {
       )}
 
       {tab === "projects" && (
-        <div style={{ display: "grid", gridTemplateColumns: "minmax(200px, 240px) 1fr", gap: 24 }}>
-          <nav style={{ borderRight: "2px solid var(--line)", paddingRight: 16 }}>
+        <div className="admin-split">
+          <nav className="admin-split-nav" aria-label="Project list">
             <p className="eyebrow" style={{ marginBottom: 12 }}>
               Projects
             </p>
@@ -468,7 +455,7 @@ function AdminWorkspace() {
             {!projectForm.id && !selectedProjectId ? (
               <p style={{ color: "var(--muted)" }}>Select a project or create a new one.</p>
             ) : (
-              <div className="card flat" style={{ padding: 20 }}>
+              <div className="card flat admin-form-card">
                 <div className="form-field">
                   <label>id (slug)</label>
                   <input
@@ -577,13 +564,12 @@ function AdminWorkspace() {
                     <ProjectThumb id={projectForm.id ?? ""} media={projectForm.media} />
                   </div>
                 </div>
-                <div className="form-field">
-                  <label>body (one paragraph per line)</label>
-                  <textarea
-                    value={bodyToLines(projectForm.body ?? [])}
-                    onChange={(e) => setProjectForm((f) => ({ ...f, body: linesToBody(e.target.value) }))}
-                  />
-                </div>
+                <AdminRichBodyEditor
+                  idPrefix="project"
+                  body={projectForm.body}
+                  onChange={(next) => setProjectForm((f) => ({ ...f, body: next }))}
+                  hint="Use the toolbar for bold, lists, links, and images. Images upload to Convex storage and appear in the project modal."
+                />
                 <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
                   <button
                     type="button"
@@ -642,7 +628,7 @@ function AdminWorkspace() {
       )}
 
       {tab === "contacts" && (
-        <div className="card flat" style={{ padding: 20 }}>
+        <div className="card flat admin-form-card">
           <p className="eyebrow" style={{ marginBottom: 16 }}>
             Contact submissions
           </p>
@@ -675,7 +661,7 @@ function AdminWorkspace() {
       )}
 
       {tab === "resume" && (
-        <div className="card flat" style={{ padding: 20 }}>
+        <div className="card flat admin-form-card">
           <p className="eyebrow" style={{ marginBottom: 16 }}>
             Upload CV PDF
           </p>
@@ -765,7 +751,7 @@ function AdminInner() {
 
   if (isLoading) {
     return (
-      <div className="wrap section-tight">
+      <div className="wrap admin-section">
         <p className="eyebrow">Checking session…</p>
       </div>
     );
@@ -773,16 +759,18 @@ function AdminInner() {
 
   if (!isAuthenticated) {
     return (
-      <div className="wrap section">
-        <header style={{ marginBottom: 28 }}>
-          <p className="eyebrow">Private</p>
-          <h1 className="display" style={{ fontSize: "clamp(2rem, 4vw, 3rem)", margin: "8px 0 0" }}>
-            Content admin
-          </h1>
-          <p style={{ color: "var(--muted)", maxWidth: 560, marginTop: 12 }}>
-            Sign in with Convex Auth (email + password). If your deployment sets{" "}
-            <code className="mono">ADMIN_EMAIL</code>, only that address can save content.
-          </p>
+      <div className="wrap admin-section">
+        <header className="admin-header-row" style={{ marginBottom: 0 }}>
+          <div>
+            <p className="eyebrow">Private</p>
+            <h1 className="display" style={{ fontSize: "clamp(2rem, 4vw, 3rem)", margin: "8px 0 0" }}>
+              Content admin
+            </h1>
+            <p style={{ color: "var(--muted)", maxWidth: 560, marginTop: 12 }}>
+              Sign in with Convex Auth (email + password). If your deployment sets{" "}
+              <code className="mono">ADMIN_EMAIL</code>, only that address can save content.
+            </p>
+          </div>
         </header>
         <AdminSignIn />
       </div>
@@ -795,7 +783,7 @@ function AdminInner() {
 export default function ContentAdmin() {
   if (!hasConvex() || !convexClient) {
     return (
-      <div className="wrap section">
+      <div className="wrap admin-section">
         <h1 className="display" style={{ fontSize: "2rem" }}>
           Convex not configured
         </h1>

--- a/src/components/portfolio/Modals.tsx
+++ b/src/components/portfolio/Modals.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import type { Post, Project } from '../../data/portfolioContent';
+import { bodyToDisplayHtml } from '../../lib/portfolioBody';
 import { ProjectThumb, ThumbPost } from './Thumbnails';
 
 /** Open in a new tab; add https:// when the URL has no scheme (e.g. admin-pasted domains). */
@@ -41,11 +42,10 @@ export function ProjectModal({ project, onClose }: { project: Project; onClose: 
             {project.title}
           </h2>
           <p style={{ fontSize: 18, color: 'var(--ink-soft)', margin: '0 0 24px' }}>{project.desc}</p>
-          {project.body.map((p, i) => (
-            <p key={i} style={{ fontSize: 16, lineHeight: 1.65, color: 'var(--ink-soft)' }}>
-              {p}
-            </p>
-          ))}
+          <div
+            className="modal-body-html"
+            dangerouslySetInnerHTML={{ __html: bodyToDisplayHtml(project.body) }}
+          />
           {project.shots && (
             <div className="modal-shots-grid">
               {project.shots.map((s, i) => (
@@ -141,11 +141,10 @@ export function PostModal({ post, onClose }: { post: Post; onClose: () => void }
             {post.title}
           </h2>
           <p style={{ fontSize: 20, lineHeight: 1.5, color: 'var(--ink-soft)', fontWeight: 500, margin: '0 0 24px' }}>{post.excerpt}</p>
-          {post.body.map((p, i) => (
-            <p key={i} style={{ fontSize: 17, lineHeight: 1.7, color: 'var(--ink-soft)' }}>
-              {p}
-            </p>
-          ))}
+          <div
+            className="modal-body-html"
+            dangerouslySetInnerHTML={{ __html: bodyToDisplayHtml(post.body) }}
+          />
           <div
             style={{
               marginTop: 32,

--- a/src/data/portfolioContent.ts
+++ b/src/data/portfolioContent.ts
@@ -12,7 +12,8 @@ export interface Project {
   repo?: string;
   itch?: string;
   media?: string;
-  body: string[];
+  /** Legacy: one paragraph per string. Rich: full HTML (from admin editor). */
+  body: string[] | string;
   shots?: string[];
 }
 
@@ -24,7 +25,8 @@ export interface Post {
   read: string;
   tag: string;
   thumb: string;
-  body: string[];
+  /** Legacy: one paragraph per string. Rich: full HTML (from admin editor). */
+  body: string[] | string;
 }
 
 export const webProjects: Project[] = [

--- a/src/lib/portfolioBody.ts
+++ b/src/lib/portfolioBody.ts
@@ -1,0 +1,117 @@
+import DOMPurify from "dompurify";
+
+/** Escape plain text for inserting into a single HTML paragraph. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Legacy Convex/static content: one string per paragraph. */
+export function paragraphsToHtml(paragraphs: string[]): string {
+  if (paragraphs.length === 0) return "<p></p>";
+  return paragraphs
+    .map((t) => {
+      const inner = escapeHtml(t).replace(/\n/g, "<br />");
+      return `<p>${inner}</p>`;
+    })
+    .join("");
+}
+
+export function bodyToHtmlForEditor(body: string[] | string | undefined): string {
+  if (body === undefined || body === null) return "<p></p>";
+  if (typeof body === "string") {
+    const t = body.trim();
+    return t ? body : "<p></p>";
+  }
+  return paragraphsToHtml(body);
+}
+
+function isEmptyBodyHtml(html: string): boolean {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const text = doc.body.textContent?.replace(/\u00a0/g, " ").trim() ?? "";
+  const hasImg = doc.body.querySelector("img");
+  return !text && !hasImg;
+}
+
+/** True when body is only top-level `<p>` with text and/or `<br>` (no inline elements). */
+function isSimpleParagraphOnly(html: string): boolean {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  for (const node of doc.body.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      if ((node.textContent ?? "").trim()) return false;
+      continue;
+    }
+    if (node.nodeName !== "P") return false;
+    for (const c of (node as HTMLParagraphElement).childNodes) {
+      if (c.nodeType === Node.TEXT_NODE) continue;
+      if (c.nodeName === "BR") continue;
+      return false;
+    }
+  }
+  return true;
+}
+
+function simpleParagraphsFromHtml(html: string): string[] {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  return [...doc.body.querySelectorAll("p")]
+    .map((p) => p.innerHTML.replace(/<br\s*\/?>/gi, "\n"))
+    .map((raw) => {
+      const t = new DOMParser().parseFromString(`<div>${raw}</div>`, "text/html").body.textContent ?? "";
+      return t.replace(/\r\n/g, "\n").trim();
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Normalizes editor HTML for Convex: compact `string[]` when plain paragraphs only,
+ * otherwise full HTML string (headings, lists, images, bold, etc.).
+ */
+export function editorHtmlToStorageBody(html: string): string[] | string {
+  const trimmed = html.trim();
+  if (!trimmed || isEmptyBodyHtml(trimmed)) return [];
+  if (isSimpleParagraphOnly(trimmed)) {
+    return simpleParagraphsFromHtml(trimmed);
+  }
+  return trimmed;
+}
+
+const SANITIZE: DOMPurify.Config = {
+  ALLOWED_TAGS: [
+    "p",
+    "br",
+    "strong",
+    "b",
+    "em",
+    "i",
+    "s",
+    "strike",
+    "a",
+    "ul",
+    "ol",
+    "li",
+    "h1",
+    "h2",
+    "h3",
+    "blockquote",
+    "pre",
+    "code",
+    "img",
+    "span",
+  ],
+  ALLOWED_ATTR: ["href", "src", "alt", "title", "target", "rel", "class"],
+  ALLOW_DATA_ATTR: false,
+};
+
+export function sanitizePortfolioBodyHtml(html: string): string {
+  return DOMPurify.sanitize(html, SANITIZE);
+}
+
+/** HTML for dangerouslySetInnerHTML in modals. */
+export function bodyToDisplayHtml(body: string[] | string | undefined): string {
+  if (body === undefined || body === null) return "";
+  const raw = typeof body === "string" ? body : paragraphsToHtml(body);
+  return sanitizePortfolioBodyHtml(raw);
+}

--- a/src/lib/portfolioBody.ts
+++ b/src/lib/portfolioBody.ts
@@ -36,46 +36,15 @@ function isEmptyBodyHtml(html: string): boolean {
   return !text && !hasImg;
 }
 
-/** True when body is only top-level `<p>` with text and/or `<br>` (no inline elements). */
-function isSimpleParagraphOnly(html: string): boolean {
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  for (const node of doc.body.childNodes) {
-    if (node.nodeType === Node.TEXT_NODE) {
-      if ((node.textContent ?? "").trim()) return false;
-      continue;
-    }
-    if (node.nodeName !== "P") return false;
-    for (const c of (node as HTMLParagraphElement).childNodes) {
-      if (c.nodeType === Node.TEXT_NODE) continue;
-      if (c.nodeName === "BR") continue;
-      return false;
-    }
-  }
-  return true;
-}
-
-function simpleParagraphsFromHtml(html: string): string[] {
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  return [...doc.body.querySelectorAll("p")]
-    .map((p) => p.innerHTML.replace(/<br\s*\/?>/gi, "\n"))
-    .map((raw) => {
-      const t = new DOMParser().parseFromString(`<div>${raw}</div>`, "text/html").body.textContent ?? "";
-      return t.replace(/\r\n/g, "\n").trim();
-    })
-    .filter(Boolean);
-}
-
 /**
- * Normalizes editor HTML for Convex: compact `string[]` when plain paragraphs only,
- * otherwise full HTML string (headings, lists, images, bold, etc.).
+ * Normalizes editor HTML for Convex. Always stores non-empty rich content as an HTML string
+ * so inline marks (bold, links, …) inside paragraphs are preserved. Empty editor → `[]`.
+ * Legacy `string[]` in the DB is still read via `bodyToHtmlForEditor` / `bodyToDisplayHtml`.
  */
 export function editorHtmlToStorageBody(html: string): string[] | string {
   const trimmed = html.trim();
   if (!trimmed || isEmptyBodyHtml(trimmed)) return [];
-  if (isSimpleParagraphOnly(trimmed)) {
-    return simpleParagraphsFromHtml(trimmed);
-  }
-  return trimmed;
+  return sanitizePortfolioBodyHtml(trimmed);
 }
 
 const SANITIZE: DOMPurify.Config = {

--- a/src/lib/portfolioBody.ts
+++ b/src/lib/portfolioBody.ts
@@ -109,7 +109,10 @@ export function sanitizePortfolioBodyHtml(html: string): string {
   return DOMPurify.sanitize(html, SANITIZE);
 }
 
-/** HTML for dangerouslySetInnerHTML in modals. */
+/**
+ * HTML for dangerouslySetInnerHTML in modals.
+ * `string[]` is treated as plain paragraphs (no inline HTML). `string` is full rich HTML from the admin editor.
+ */
 export function bodyToDisplayHtml(body: string[] | string | undefined): string {
   if (body === undefined || body === null) return "";
   const raw = typeof body === "string" ? body : paragraphsToHtml(body);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -546,22 +546,114 @@ button { font-family: inherit; cursor: pointer; }
 }
 .admin-rich-editor-content a { color: var(--cobalt); text-decoration: underline; text-underline-offset: 2px; }
 
-/* Portfolio modals: sanitized rich body */
+/* Portfolio modals: sanitized rich body (matches admin editor semantics) */
 .modal-body-html {
-  font-size: 16px; line-height: 1.65; color: var(--ink-soft);
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--ink-soft);
 }
 .modal-body-html p { margin: 0 0 0.85em; }
 .modal-body-html p:last-child { margin-bottom: 0; }
-.modal-body-html h2 { font-family: var(--font-display); font-weight: 800; font-size: clamp(1.35rem, 3vw, 1.75rem); margin: 1em 0 0.45em; letter-spacing: -0.02em; color: var(--ink); }
-.modal-body-html h3 { font-family: var(--font-display); font-weight: 800; font-size: clamp(1.15rem, 2.5vw, 1.35rem); margin: 0.9em 0 0.4em; color: var(--ink); }
-.modal-body-html ul, .modal-body-html ol { margin: 0 0 0.85em; padding-left: 1.25em; }
+.modal-body-html strong,
+.modal-body-html b {
+  font-weight: 700;
+  color: var(--ink);
+}
+.modal-body-html em,
+.modal-body-html i {
+  font-style: italic;
+}
+.modal-body-html s,
+.modal-body-html strike {
+  text-decoration: line-through;
+  color: var(--muted);
+}
+.modal-body-html h1 {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: clamp(1.5rem, 3.5vw, 2rem);
+  margin: 1em 0 0.5em;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  color: var(--ink);
+}
+.modal-body-html h1:first-child { margin-top: 0; }
+.modal-body-html h2 {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: clamp(1.35rem, 3vw, 1.75rem);
+  margin: 1em 0 0.45em;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+.modal-body-html h2:first-child { margin-top: 0; }
+.modal-body-html h3 {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: clamp(1.15rem, 2.5vw, 1.35rem);
+  margin: 0.9em 0 0.4em;
+  color: var(--ink);
+}
+.modal-body-html h3:first-child { margin-top: 0; }
+.modal-body-html ul,
+.modal-body-html ol {
+  margin: 0 0 0.85em;
+  padding-left: 1.35em;
+}
+.modal-body-html li { margin: 0.25em 0; padding-left: 0.15em; }
+.modal-body-html li::marker { color: var(--muted); }
 .modal-body-html blockquote {
-  margin: 0 0 0.85em; padding-left: 14px; border-left: 3px solid var(--line); color: var(--ink-soft);
+  margin: 0 0 0.85em;
+  padding: 10px 14px 10px 16px;
+  border-left: 4px solid var(--cobalt);
+  background: var(--paper-2);
+  border-radius: 0 10px 10px 0;
+  color: var(--ink-soft);
+}
+.modal-body-html pre {
+  margin: 0 0 0.85em;
+  padding: 14px 16px;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.5;
+  border: 2px solid var(--line);
+  border-radius: 12px;
+  background: var(--paper-2);
+  color: var(--ink);
+}
+.modal-body-html code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  padding: 0.12em 0.4em;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+  background: var(--paper-2);
+  color: var(--ink);
+}
+.modal-body-html pre code {
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-size: inherit;
 }
 .modal-body-html img {
-  max-width: 100%; height: auto; border-radius: 10px; border: 2px solid var(--line); display: block; margin: 0.85em 0;
+  max-width: 100%;
+  height: auto;
+  border-radius: 10px;
+  border: 2px solid var(--line);
+  display: block;
+  margin: 0.85em 0;
 }
-.modal-body-html a { color: var(--cobalt); }
+.modal-body-html a {
+  color: var(--cobalt);
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.modal-body-html a:hover {
+  color: var(--ink);
+}
 
 .resume-row {
   display: grid; grid-template-columns: 160px 1fr 120px; gap: 28px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -470,6 +470,99 @@ button { font-family: inherit; cursor: pointer; }
 }
 .form-field textarea { min-height: 140px; resize: vertical; }
 
+/* —— Content admin: layout + rich body editor —— */
+.admin-section { padding-block: clamp(40px, 10vw, 96px); }
+.admin-header-row {
+  display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-between; gap: 16px;
+  margin-bottom: 32px;
+}
+.admin-tab-bar {
+  display: flex; flex-wrap: nowrap; gap: 8px; margin-bottom: 20px; overflow-x: auto;
+  -webkit-overflow-scrolling: touch; padding-bottom: 4px; scrollbar-width: thin;
+}
+.admin-tab-bar::-webkit-scrollbar { height: 4px; }
+.admin-tab-bar::-webkit-scrollbar-thumb { background: var(--line); border-radius: 999px; }
+.admin-tab-bar .btn { flex: 0 0 auto; white-space: nowrap; }
+.admin-split {
+  display: grid; grid-template-columns: minmax(200px, 240px) 1fr; gap: 24px; align-items: start;
+}
+.admin-split-nav { border-right: 2px solid var(--line); padding-right: 16px; }
+.admin-split-nav ul {
+  max-height: min(52vh, 420px); overflow-y: auto; -webkit-overflow-scrolling: touch;
+}
+.admin-form-card { padding: 20px; }
+@media (max-width: 768px) {
+  .admin-split { grid-template-columns: 1fr; gap: 20px; }
+  .admin-split-nav {
+    border-right: none; border-bottom: 2px solid var(--line);
+    padding-right: 0; padding-bottom: 16px;
+  }
+  .admin-split-nav ul { max-height: min(36vh, 280px); }
+  .admin-form-card { padding: 16px; }
+}
+.admin-body-editor-hint {
+  font-size: 13px; color: var(--muted); line-height: 1.45; margin: 0 0 4px;
+}
+.admin-body-meta {
+  font-family: var(--font-mono); font-size: 11px; color: var(--muted); letter-spacing: 0.06em;
+}
+.admin-rich-editor-wrap {
+  border: 2px solid var(--line); border-radius: 12px; background: var(--bg);
+  overflow: hidden; max-width: 100%;
+}
+.admin-rich-toolbar {
+  display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
+  padding: 10px 12px; border-bottom: 2px solid var(--line); background: var(--paper-2);
+}
+.admin-rich-toolbar-sep {
+  width: 1px; height: 22px; background: var(--line); margin: 0 4px;
+}
+.admin-rich-tool {
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase;
+  padding: 8px 10px; border-radius: 8px; border: 2px solid var(--line); background: var(--bg); color: var(--ink);
+  cursor: pointer; transition: box-shadow var(--t-fast), transform var(--t-fast);
+}
+.admin-rich-tool:hover:not(:disabled) { box-shadow: var(--shadow-sm); transform: translate(-1px, -1px); }
+.admin-rich-tool:disabled { opacity: 0.55; cursor: not-allowed; }
+.admin-rich-tool.is-active {
+  background: var(--ink); color: var(--bg); border-color: var(--ink);
+}
+.admin-rich-editor-content {
+  min-height: min(52vh, 420px); max-height: min(70vh, 560px); overflow-y: auto;
+  padding: 16px 18px; font-size: 16px; line-height: 1.6; color: var(--ink);
+  -webkit-overflow-scrolling: touch;
+}
+.admin-rich-editor-content:focus { outline: none; }
+.admin-rich-editor-content p { margin: 0 0 0.85em; }
+.admin-rich-editor-content p:last-child { margin-bottom: 0; }
+.admin-rich-editor-content h2, .admin-rich-editor-content h3 { margin: 1.1em 0 0.5em; line-height: 1.2; }
+.admin-rich-editor-content h2:first-child, .admin-rich-editor-content h3:first-child { margin-top: 0; }
+.admin-rich-editor-content ul, .admin-rich-editor-content ol { margin: 0 0 0.85em; padding-left: 1.35em; }
+.admin-rich-editor-content blockquote {
+  margin: 0 0 0.85em; padding-left: 14px; border-left: 3px solid var(--line); color: var(--ink-soft);
+}
+.admin-rich-editor-content img {
+  max-width: 100%; height: auto; border-radius: 10px; border: 2px solid var(--line); display: block; margin: 0.75em 0;
+}
+.admin-rich-editor-content a { color: var(--cobalt); text-decoration: underline; text-underline-offset: 2px; }
+
+/* Portfolio modals: sanitized rich body */
+.modal-body-html {
+  font-size: 16px; line-height: 1.65; color: var(--ink-soft);
+}
+.modal-body-html p { margin: 0 0 0.85em; }
+.modal-body-html p:last-child { margin-bottom: 0; }
+.modal-body-html h2 { font-family: var(--font-display); font-weight: 800; font-size: clamp(1.35rem, 3vw, 1.75rem); margin: 1em 0 0.45em; letter-spacing: -0.02em; color: var(--ink); }
+.modal-body-html h3 { font-family: var(--font-display); font-weight: 800; font-size: clamp(1.15rem, 2.5vw, 1.35rem); margin: 0.9em 0 0.4em; color: var(--ink); }
+.modal-body-html ul, .modal-body-html ol { margin: 0 0 0.85em; padding-left: 1.25em; }
+.modal-body-html blockquote {
+  margin: 0 0 0.85em; padding-left: 14px; border-left: 3px solid var(--line); color: var(--ink-soft);
+}
+.modal-body-html img {
+  max-width: 100%; height: auto; border-radius: 10px; border: 2px solid var(--line); display: block; margin: 0.85em 0;
+}
+.modal-body-html a { color: var(--cobalt); }
+
 .resume-row {
   display: grid; grid-template-columns: 160px 1fr 120px; gap: 28px;
   padding: 18px 0; border-bottom: 2px dashed var(--line); align-items: baseline;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replaced the post/project **body** field in `/admin` with a **single scrollable TipTap editor** (toolbar + tall editor area with its own scroll).
- Supports **bold, italic, strikethrough, H2/H3, bullet/ordered lists, blockquote, links**, and **inline images**. Images use a new admin mutation `generateBodyImageUploadUrl`, then `getBodyImageUrl` to resolve a public URL embedded in the HTML.
- **Convex schema**: `posts.body` and `projects.body` are now `string[] | string`. **New saves from the admin editor** store non-empty body as **sanitized HTML** (including bold/links inside paragraphs). Legacy `string[]` from static data or old Convex rows still render as plain paragraphs.
- **Save fix:** Previously, “only `<p>` blocks” was incorrectly saved as `string[]`, which **stripped inline formatting** via `textContent` — so modals on home / web / games never showed bold. `editorHtmlToStorageBody` now always persists non-empty editor HTML (sanitized).
- **Site modals** render body via DOMPurify-sanitized HTML (`bodyToDisplayHtml`). **Modal CSS** styles inline and block elements so formatting is visible.

## Dependencies

- `@tiptap/react`, `@tiptap/starter-kit`, `@tiptap/extension-placeholder`, `@tiptap/extension-image`, `@tiptap/extension-link`, `dompurify` (+ `@types/dompurify`).

## Deploy notes

- Run `npx convex dev` (or deploy) so the schema change and new `assets` functions apply. Existing documents with `body: string[]` remain valid.

## Test plan

- [x] `npm run build`
- [ ] After Convex deploy: edit a project body with bold only in paragraphs, save, open project modal on home — bold should appear.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56c1d981-95b0-4ee5-866b-8f1b5f12ba81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56c1d981-95b0-4ee5-866b-8f1b5f12ba81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

