### PR TITLE
Add Hintless Devlog post and game card

### DIFF
--- a/src/components/portfolio/Thumbnails.tsx
+++ b/src/components/portfolio/Thumbnails.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import type { Post } from '../../data/portfolioContent';
 
-// ─── PRNG ─────────────────────────────────────────────────────────────────────
+// ─── PRNG ─────────────────────────────────────────────────────────────
 
 function mulberry32(seed: number) {
   return function () {
@@ -12,7 +12,7 @@ function mulberry32(seed: number) {
   };
 }
 
-// ─── Project thumb SVGs ───────────────────────────────────────────────────────
+// ─── Project thumb SVGs ───────────────────────────────────────────────
 
 function ThumbAtlas() {
   return (
@@ -152,6 +152,19 @@ function ThumbThicket() {
   );
 }
 
+function ThumbHintless() {
+  return (
+    <svg viewBox="0 0 400 250" preserveAspectRatio="xMidYMid slice" style={{ width: '100%', height: '100%', display: 'block' }}>
+      <rect width="400" height="250" fill="#141414" />
+      <rect x="36" y="48" width="96" height="140" fill="#6B2BFF" stroke="#FFC83D" strokeWidth="4" />
+      <rect x="152" y="36" width="96" height="164" fill="#FF3B1F" stroke="#FFC83D" strokeWidth="4" />
+      <rect x="268" y="48" width="96" height="140" fill="#6B2BFF" stroke="#FFC83D" strokeWidth="4" />
+      <text x="20" y="32" fontFamily="JetBrains Mono, monospace" fontSize="10" fontWeight="700" fill="#FFC83D" letterSpacing="2">GALLERY · 3 PORTRAITS</text>
+      <text x="200" y="228" textAnchor="middle" fontFamily="Bricolage Grotesque, sans-serif" fontWeight="800" fontSize="22" fill="#F4EFE6" letterSpacing="-1">HINTLESS</text>
+    </svg>
+  );
+}
+
 const THUMB_MAP: Record<string, () => ReactElement> = {
   atlas: ThumbAtlas,
   field: ThumbField,
@@ -161,6 +174,7 @@ const THUMB_MAP: Record<string, () => ReactElement> = {
   rewind: ThumbRewind,
   lattice: ThumbLattice,
   thicket: ThumbThicket,
+  hintless: ThumbHintless,
 };
 
 /** Absolute URL for <img src>; add https:// when there is no scheme (e.g. admin-pasted domains). */

--- a/src/data/portfolioContent.ts
+++ b/src/data/portfolioContent.ts
@@ -98,6 +98,22 @@ export const webProjects: Project[] = [
 
 export const gameProjects: Project[] = [
   {
+    id: 'hintless',
+    title: 'Hintless',
+    year: '2026',
+    kind: 'game',
+    role: 'Design, Code',
+    desc: 'An asymmetric multiplayer puzzle game. One Curator, 1–4 Explorers, and hints you should not fully trust.',
+    tags: ['Godot', 'GDScript', 'Multiplayer'],
+    accent: 'plum',
+    thumb: 'hintless',
+    body: [
+      'One player hosts as the Curator. Everyone else explores a gallery and solves a puzzle chain while the hints get unreliable.',
+      'Lights Out is the sabotage: a temporary blackout of one room, host-authoritative, on a cooldown. It does not block the puzzle.',
+      'Still in prototype. No Steam page yet. The loop is lobby to round to lobby, no restart.',
+    ],
+  },
+  {
     id: 'moth',
     title: 'Moth',
     year: '2025',
@@ -164,6 +180,21 @@ export const gameProjects: Project[] = [
 ];
 
 export const posts: Post[] = [
+  {
+    id: 'p005',
+    date: '2026-08',
+    title: 'Trust no one. Especially your friends.',
+    excerpt:
+      'Hintless is an asymmetric multiplayer puzzle game I am building in Godot 4. One Curator, a few Explorers, and hints you should not fully trust.',
+    read: '5 min',
+    tag: 'Devlog',
+    thumb: 'devlog',
+    body: [
+      'Hintless is a 2–5 player game: one Curator, one to four Explorers, Steam P2P. The tagline is doing a lot of work on purpose.',
+      'The round is one graybox gallery, one puzzle chain I am calling Three Portraits, hints that might be true or might not, then a Lights Out sabotage. Back to the lobby without restarting.',
+      'Current milestone is a playable friendslop prototype. Art direction is a brutalist surrealist gallery — burgundy, gold, dark wood, funny horror. Godot 4 is already in.',
+    ],
+  },
   {
     id: 'p001',
     date: '2026-04',

--- a/src/hooks/usePortfolioContent.ts
+++ b/src/hooks/usePortfolioContent.ts
@@ -3,6 +3,11 @@ import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
 import { normalizeBody } from "../../convex/lib/normalizeBody";
 import type { Post, Project } from "../data/portfolioContent";
+import {
+  gameProjects as staticGameProjects,
+  posts as staticPosts,
+  webProjects as staticWebProjects,
+} from "../data/portfolioContent";
 import { hasConvex } from "../lib/convexClient";
 
 function docToProject(d: Doc<"projects">): Project {
@@ -38,8 +43,14 @@ function docToPost(d: Doc<"posts">): Post {
   };
 }
 
+function unionById<T extends { id: string }>(remote: T[], local: T[]): T[] {
+  const seen = new Set(remote.map((item) => item.id));
+  return [...remote, ...local.filter((item) => !seen.has(item.id))];
+}
+
 /**
  * Loads posts and projects from Convex when PUBLIC_CONVEX_URL is set.
+ * Static repo content fills any ids Convex does not have yet.
  */
 export function usePortfolioContent(): {
   webProjects: Project[];
@@ -51,7 +62,16 @@ export function usePortfolioContent(): {
   const allProjects = useQuery(api.projects.listProjects, useRemote ? {} : "skip");
   const remotePosts = useQuery(api.posts.listPosts, useRemote ? {} : "skip");
 
-  if (!useRemote || allProjects === undefined || remotePosts === undefined) {
+  if (!useRemote) {
+    return {
+      webProjects: staticWebProjects,
+      gameProjects: staticGameProjects,
+      posts: staticPosts,
+      fromConvex: false,
+    };
+  }
+
+  if (allProjects === undefined || remotePosts === undefined) {
     return {
       webProjects: [],
       gameProjects: [],
@@ -60,9 +80,17 @@ export function usePortfolioContent(): {
     };
   }
 
-  const webProjects = allProjects.filter((p) => p.kind === "web").map(docToProject);
-  const gameProjects = allProjects.filter((p) => p.kind === "game").map(docToProject);
-  const posts = remotePosts.map(docToPost);
+  const webProjects = unionById(
+    allProjects.filter((p) => p.kind === "web").map(docToProject),
+    staticWebProjects,
+  );
+  const gameProjects = unionById(
+    allProjects.filter((p) => p.kind === "game").map(docToProject),
+    staticGameProjects,
+  );
+  const posts = unionById(remotePosts.map(docToPost), staticPosts).sort((a, b) =>
+    a.date < b.date ? 1 : a.date > b.date ? -1 : 0,
+  );
 
   return { webProjects, gameProjects, posts, fromConvex: true };
 }


### PR DESCRIPTION
Adds a Devlog post and a Games card for Hintless, based on the in-progress prototype in Notion (asymmetric multiplayer, Curator + Explorers, Three Portraits, Lights Out).

Also unions static repo content into Convex lists by id, so Hintless shows on the live site after deploy even before it is upserted in `/admin`.

Not merged.